### PR TITLE
ci: Check Pull Request Title Prefix

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -8,6 +8,15 @@ permissions:
   pull-requests: read
 
 jobs:
+  check-pr-title:
+    name: Check Pull Request Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Pull Request Title
+        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
+        with:
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix
+
   common-pull-request-tasks:
     name: Common Pull Request Tasks
     permissions:


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new workflow job to automatically check the format of pull request titles in the GitHub Actions pipeline. This helps enforce consistency and best practices in PR naming.

Workflow automation:

* Added a `check-pr-title` job to `.github/workflows/pull-request-tasks.yml` that uses the `deepakputhraya/action-pr-title` GitHub Action to ensure pull request titles start with one of the allowed prefixes.
