### PR TITLE
ci: Disable Go Linting with SuperLinter

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -37,6 +37,9 @@ jobs:
           YAML_ERROR_ON_WARNING: true
           VALIDATE_GIT_COMMITLINT: false
           VALIDATE_EDITORCONFIG: false
+          VALIDATE_GO: false
+          VALIDATE_GO_MODULES: false
+          VALIDATE_GO_RELEASER: false
 
   common-code-checks:
     name: Common Code Checks


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the `.github/workflows/code-checks.yml` configuration by disabling several Go-related validation checks.

* Disabled Go validation checks by setting `VALIDATE_GO`, `VALIDATE_GO_MODULES`, and `VALIDATE_GO_RELEASER` to `false` in the workflow configuration.
