### PR TITLE
chore: Add Go GitHub Pull Request Tags

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,18 +25,13 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
-python:
+go:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["*.py", "**/*.py"]
-typescript:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file:
-              ["*.ts", "*.tsx", "**/*.ts", "**/*.tsx", "**/tsconfig.json"]
+          - any-glob-to-any-file: ["*.go", "go.mod", "go.sum"]
 shell:
   - any:
       - changed-files:

--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -45,12 +45,9 @@
 - color: 66A615
   name: just
   description: Pull requests that update Just code
-- color: 2b67c6
-  name: python
-  description: Pull requests that update Python code
-- color: 00ff1e
-  name: typescript
-  description: Pull requests that update TypeScript code
+- color: 006B75
+  name: go
+  description: Pull requests that update Go code
 # Components
 - color: ff0073
   name: git_hooks


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the configuration for code labeling to remove Python and TypeScript support and add Go support. The changes affect both the label definitions and the file patterns used to detect Go-related changes.

Label configuration updates:

* Removed the `python` and `typescript` labels from `.github/other-configurations/labels.yml`, and added a new `go` label for Go code changes.

Labeller configuration updates:

* Changed the file pattern for license detection from `LICENSE` to `LICENCE` in the `markdown` group in `.github/other-configurations/labeller.yml`.
* Removed Python file glob patterns and added Go file glob patterns (`*.go`, `go.mod`, `go.sum`) to the labeller configuration.
* Removed TypeScript file glob patterns from the labeller configuration.