### PR TITLE
ci: Run Action on each PR

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -23,7 +23,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,27 @@
+name: "Test Action"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions: {}
+
+jobs:
+  test-action:
+    name: Test Action
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Run Test Action
+        uses: ./
+        with:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description


This pull request updates the GitHub Actions configuration by upgrading the checkout action to the latest major version and introducing a new workflow for testing the repository’s custom action. These changes improve CI reliability and add automated testing for the custom action.

**CI/CD Workflow Updates**

* Upgraded the `actions/checkout` step in `.github/workflows/code-checks.yml` from version `v4.2.2` to `v5.0.0` to ensure compatibility and benefit from the latest improvements.

**New Workflow Addition**

* Added a new workflow file `.github/workflows/test-action.yml` that runs on pushes to `main`, pull requests, manual dispatch, and a nightly schedule. This workflow checks out the repository and runs the custom action with the required `GITHUB_TOKEN` input.

Fixes #22
