### PR TITLE
build: Use collected stats in SVG

### DIFF
--- a/src/features.go
+++ b/src/features.go
@@ -22,7 +22,11 @@ func generateSVGContent(svgCanvas *svg.SVG) {
 	handle := "@" + userName
 	drawStandardHeader(svgCanvas, cardX, cardY, cardW, avatarURL, handle, displayName)
 
-	prTotal, _ := getPullRequestTotal(userName)
+	prTotal, prErr := getPullRequestTotal(userName)
+	if prErr != nil {
+		zap.L().Error("Failed to get pull request total", zap.Error(prErr))
+		prTotal = -1 // Sentinel value indicating error
+	}
 	issuesTotal, err := getIssuesTotal(userName)
 	if err != nil {
 		zap.L().Error("Failed to get GitHub issues total", zap.Error(err))

--- a/src/features.go
+++ b/src/features.go
@@ -23,7 +23,11 @@ func generateSVGContent(svgCanvas *svg.SVG) {
 	drawStandardHeader(svgCanvas, cardX, cardY, cardW, avatarURL, handle, displayName)
 
 	prTotal, _ := getPullRequestTotal(userName)
-	issuesTotal, _ := getIssuesTotal(userName)
+	issuesTotal, err := getIssuesTotal(userName)
+	if err != nil {
+		zap.L().Error("Failed to get GitHub issues total", zap.Error(err))
+		return
+	}
 	drawMetrics(svgCanvas, cardX, cardY, prTotal, issuesTotal)
 	drawLanguageBars(svgCanvas, cardX, cardY)
 	drawFooter(svgCanvas, cardX, cardY, cardH)

--- a/src/features.go
+++ b/src/features.go
@@ -22,9 +22,9 @@ func generateSVGContent(svgCanvas *svg.SVG) {
 	handle := "@" + userName
 	drawStandardHeader(svgCanvas, cardX, cardY, cardW, avatarURL, handle, displayName)
 
-	getPullRequestTotal(userName)
-	getIssuesTotal(userName)
-	drawMetrics(svgCanvas, cardX, cardY)
+	prTotal, _ := getPullRequestTotal(userName)
+	issuesTotal, _ := getIssuesTotal(userName)
+	drawMetrics(svgCanvas, cardX, cardY, prTotal, issuesTotal)
 	drawLanguageBars(svgCanvas, cardX, cardY)
 	drawFooter(svgCanvas, cardX, cardY, cardH)
 }

--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -35,7 +35,6 @@ func getPullRequestTotal(username string) (int, error) {
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		fmt.Printf("Failed to decode pull request total response: %v\n", err)
 		return 0, fmt.Errorf("Failed to decode pull request total response: %w", err)
 	}
 
@@ -57,14 +56,12 @@ func getIssuesTotal(username string) (int, error) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Printf("Failed to query GitHub API for issues total: %v\n", err)
-		return 0, err
+		return 0, fmt.Errorf("Failed to query GitHub API for issues total: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		fmt.Printf("GitHub API returned status %d for issues total\n", resp.StatusCode)
-		return 0, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+		return 0, fmt.Errorf("GitHub API returned status %d for issues total	", resp.StatusCode)
 	}
 
 	var result struct {
@@ -72,8 +69,7 @@ func getIssuesTotal(username string) (int, error) {
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		fmt.Printf("Failed to decode issues total response: %v\n", err)
-		return 0, err
+		return 0, fmt.Errorf("Failed to decode issues total response: %w", err)
 	}
 
 	fmt.Printf("Total issues by %s: %d\n", username, result.TotalCount)

--- a/src/svg.go
+++ b/src/svg.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 
 	svg "github.com/ajstarks/svgo"
 	"go.uber.org/zap"
@@ -45,7 +46,7 @@ func drawHeader(canvas *svg.SVG, cardX, cardY int, username string, tag string) 
 }
 
 // drawMetrics renders the three metric boxes (commits, PRs, issues).
-func drawMetrics(canvas *svg.SVG, cardX, cardY int) {
+func drawMetrics(canvas *svg.SVG, cardX, cardY int, prTotal int, issuesTotal int) {
 	boxW, boxH := 180, 64
 	gap := 16
 	startX := cardX + 22
@@ -59,13 +60,13 @@ func drawMetrics(canvas *svg.SVG, cardX, cardY int) {
 	// PRs
 	prX := startX + boxW + gap
 	canvas.Roundrect(prX, startY, boxW, boxH, 8, 8, "fill:#071029")
-	canvas.Text(prX+14, startY+26, "84", "fill:#ffd580;font-size:20px;font-weight:700")
+	canvas.Text(prX+14, startY+26, strconv.Itoa(prTotal), "fill:#ffd580;font-size:20px;font-weight:700")
 	canvas.Text(prX+14, startY+46, "pull requests", "fill:#9aa6b8;font-size:12px")
 
 	// Issues
 	issuesX := prX + boxW + gap
 	canvas.Roundrect(issuesX, startY, boxW, boxH, 8, 8, "fill:#071029")
-	canvas.Text(issuesX+14, startY+26, "12", "fill:#ff9b9b;font-size:20px;font-weight:700")
+	canvas.Text(issuesX+14, startY+26, strconv.Itoa(issuesTotal), "fill:#ff9b9b;font-size:20px;font-weight:700")
 	canvas.Text(issuesX+14, startY+46, "open issues", "fill:#9aa6b8;font-size:12px")
 }
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors how pull request and issue totals are fetched and displayed in the SVG output. The main improvement is that the metrics boxes now show the actual number of pull requests and issues for a user, instead of hardcoded values. This was achieved by updating the data-fetching functions to return values and passing those values through to the SVG rendering logic.

**Metrics calculation and display improvements:**

* Updated `getPullRequestTotal` and `getIssuesTotal` in `src/github_queries.go` to return the actual totals and errors, instead of printing and returning nothing, which allows these values to be used elsewhere in the code. [[1]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L13-R30) [[2]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L42-R67) [[3]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L78-R80)
* Refactored `drawMetrics` in `src/svg.go` to accept `prTotal` and `issuesTotal` as parameters and display them in the SVG, replacing the previously hardcoded values. [[1]](diffhunk://#diff-13c5ff68001f0e8ef10d61c67a3e6cd06d17a3044b11cd2a24e5ec8c4b67230aL48-R49) [[2]](diffhunk://#diff-13c5ff68001f0e8ef10d61c67a3e6cd06d17a3044b11cd2a24e5ec8c4b67230aL62-R69)
* Modified `generateSVGContent` in `src/features.go` to fetch the metrics, capture their values, and pass them to `drawMetrics`.

**Codebase maintenance:**

* Added the `strconv` import in `src/svg.go` to convert integers to strings for SVG rendering.
