### PR TITLE
chore: Add default branch variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,3 +19,7 @@ inputs:
     description: "Enable debug logging"
     required: false
     default: "false"
+  default_branch:
+    description: "The default branch name"
+    required: true
+    default: "main"


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small update to the `action.yml` file by adding a new required input parameter for the default branch name.

* Added a new `default_branch` input to `action.yml`, which specifies the default branch name and sets its default value to `main`.