### PR TITLE
feat: Commit SVG to Repository

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -26,3 +26,5 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           debug: "true"
+          test_mode: "true"
+          output_file_name: "test.svg"

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,6 @@ inputs:
     description: "Enable debug logging"
     required: false
     default: "false"
-  default_branch:
-    description: "The default branch name"
-    required: true
-    default: "main"
   test_mode:
     description: "Enable test mode"
     required: false
@@ -31,3 +27,7 @@ inputs:
     description: "The GitHub repository (owner/repo)"
     required: true
     default: ${{ github.repository }}
+  output_file_name:
+    description: "The name of the output file"
+    required: true
+    default: "output.svg"

--- a/src/commit.go
+++ b/src/commit.go
@@ -44,7 +44,7 @@ func commitSVGChanges(file *os.File) {
 	zap.L().Debug("SVG file copied to repo", zap.String("dest", destPath))
 
 	// Commit the changes to the repo.
-	err = commitChanges(repoPath)
+	err = commitChanges(repoPath, outputFileName)
 	if err != nil {
 		zap.L().Fatal("Failed to commit changes", zap.Error(err))
 	}

--- a/src/commit.go
+++ b/src/commit.go
@@ -116,7 +116,7 @@ func commitChanges(repoPath string, outputFileName string) error {
 				password: token,
 		},
 		RemoteURL: remoteURL,
-	})
+	})}
 	if err != nil {
 		return fmt.Errorf("failed to push: %w", err)
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -28,6 +28,5 @@ func main() {
 	svgCanvas := setupSVG(file)
 	generateSVGContent(svgCanvas)
 	completeSVG(svgCanvas)
-
-	commitSVGChanges()
+	commitSVGChanges(file)
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces improvements to the GitHub Action workflow and the `commit.go` implementation, focusing on enhanced configurability and reliability for committing SVG files to a repository. The main changes include new input parameters for test mode and output file name, removal of an unused input, and a refactor of the commit logic to support these options and ensure robust error handling.

**Workflow and Action Configuration Enhancements:**

* Added `test_mode` and `output_file_name` inputs to both `.github/workflows/test-action.yml` and `action.yml`, allowing users to enable test mode and specify the name of the output SVG file. This improves flexibility for testing and output management. [[1]](diffhunk://#diff-9ccfc6831832281d3954ef7726f4e6f48623922b4054660913b9970a47774558R29-R30) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L22-L25) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R30-R33)
* Removed the unused `default_branch` input from `action.yml`, simplifying the action configuration.

**Commit Logic Refactoring and Reliability Improvements:**

* Refactored `commitSVGChanges` in `src/commit.go` to accept a file parameter, copy the generated SVG to the cloned repository using the specified output file name, and added robust error handling with fatal logging for critical failures. [[1]](diffhunk://#diff-d4596480fdccff713fe198cbf0bcf98788bf6179c05e3588799032ed6555921eR8-R53) [[2]](diffhunk://#diff-9e185f29fa355d7dd8fdd9c9ff1d0723b85206aa7d37c4eec93997005dc291ebL31-R31)
* Implemented the new `commitChanges` function in `src/commit.go` to commit and push changes with GitHub Actions bot credentials, supporting test mode (skipping push if enabled) and using the provided GitHub token for authentication.

Fixes #68
