### PR TITLE
build: Add Commit Message and Output File Name Variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,3 +35,7 @@ inputs:
     description: "The name of the output file"
     required: true
     default: "output.svg"
+  commit_message:
+    description: "The commit message"
+    required: false
+    default: "Update Coding Metrics"

--- a/src/commit.go
+++ b/src/commit.go
@@ -21,7 +21,8 @@ func commitSVGChanges(file *os.File) {
 	parts := strings.Split(ownerRepo, "/")
 	branch := "main"
 	token := os.Getenv("INPUT_WORKFLOW_GITHUB_TOKEN")
-	path := "output.svg"
+	path := os.Getenv("INPUT_OUTPUT_FILE_NAME")
+	commitMessage := os.Getenv("INPUT_COMMIT_MESSAGE")
 	if len(parts) != 2 {
 		zap.L().Fatal("Invalid repository format", zap.String("repository", ownerRepo))
 		return
@@ -46,7 +47,7 @@ func commitSVGChanges(file *os.File) {
 		return
 	}
 	opts := &github.RepositoryContentFileOptions{
-		Message: github.String("Update SVG file"),
+		Message: github.String(commitMessage),
 		Content: contentBytes,
 		SHA:     sha, // nil if new file
 		Branch:  github.String(branch),


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds support for customizing the commit message when updating the SVG output file. The main changes involve allowing users to specify a commit message via workflow inputs and updating the code to use this message during the commit process.

**Workflow input enhancements:**

* Added a new optional input `commit_message` to `action.yml`, allowing users to specify a custom commit message for SVG updates.

**Code updates for commit customization:**

* Modified `src/commit.go` to read the `commit_message` input from the environment and use it as the commit message instead of the previous hardcoded value. [[1]](diffhunk://#diff-d4596480fdccff713fe198cbf0bcf98788bf6179c05e3588799032ed6555921eL24-R25) [[2]](diffhunk://#diff-d4596480fdccff713fe198cbf0bcf98788bf6179c05e3588799032ed6555921eL49-R50)
* Changed the file path assignment in `src/commit.go` to use the `INPUT_OUTPUT_FILE_NAME` environment variable, ensuring consistency with the workflow input for the output file name.