### PR TITLE
ci: Add Go Fmt Check Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -54,4 +54,3 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       - name: Check Go Code Format
         run: just fmt-check
-

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Setup Go environment
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       - name: Check Go Code Format

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -44,12 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Go environment
-        uses: actions/setup-go@v5.5.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       - name: Check Go Code Format
         run: just fmt-check
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -38,3 +38,18 @@ jobs:
     uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@1a353cd8db3393047830eaa51f6ce11eac29f94b # v2025.08.21.05
     with:
       language: ${{ matrix.language }}
+
+  run-go-format-checks:
+    name: Run Go Format Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Go environment
+        uses: actions/setup-go@v5.5.0
+      - name: Check Go Code Format
+        run: just fmt-check
+

--- a/Justfile
+++ b/Justfile
@@ -5,6 +5,21 @@
 run:
     go run ./src
 
+fmt:
+    go fmt ./src
+
+fmt-check:
+    if [ -z "$(gofmt -l .)" ];
+    then
+        echo "OK: all Go files are go formatted."
+    else
+        echo "Not go formatted:"
+        gofmt -l .
+        echo "Diff:"
+        gofmt -d .;
+        exit 1;
+    fi
+
 # ------------------------------------------------------------------------------
 # Docker
 # ------------------------------------------------------------------------------

--- a/Justfile
+++ b/Justfile
@@ -9,15 +9,14 @@ fmt:
     go fmt ./src
 
 fmt-check:
-    if [ -z "$(gofmt -l .)" ];
-    then
-        echo "OK: all Go files are go formatted."
-    else
-        echo "Not go formatted:"
-        gofmt -l .
-        echo "Diff:"
-        gofmt -d .;
-        exit 1;
+    @if [ -z "$(gofmt -l .)" ]; \
+        then echo "OK: all Go files are go formatted."; \
+    else \
+        echo "Not go formatted:"; \
+        gofmt -l .; \
+        echo "Diff:"; \
+        gofmt -d .; \
+        exit 1; \
     fi
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces automated Go code formatting checks to the CI workflow and adds corresponding commands to the `Justfile`. These changes help ensure that all Go code adheres to formatting standards before merging, improving code quality and consistency.

**Continuous Integration improvements:**

* Added a new `run-go-format-checks` job to the `.github/workflows/code-checks.yml` workflow to automatically verify Go code formatting using the `just fmt-check` command.

**Developer tooling enhancements:**

* Added `fmt` and `fmt-check` recipes to the `Justfile` to format Go code and check for formatting issues, respectively. The `fmt-check` command will fail if any files are not properly formatted, displaying the differences.

Fixes #12 
