### PR TITLE
build: Add another variable to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: "The GitHub repository (owner/repo)"
     required: true
     default: ${{ github.repository }}
+  output_branch:
+    description: "The branch to commit the changes to"
+    required: true
+    default: "main"
   output_file_name:
     description: "The name of the output file"
     required: true

--- a/src/commit.go
+++ b/src/commit.go
@@ -19,7 +19,7 @@ func commitSVGChanges(file *os.File) {
 	}
 	ownerRepo := os.Getenv("INPUT_REPOSITORY")
 	parts := strings.Split(ownerRepo, "/")
-	branch := "main"
+	branch := os.Getenv("INPUT_OUTPUT_BRANCH")
 	token := os.Getenv("INPUT_WORKFLOW_GITHUB_TOKEN")
 	path := os.Getenv("INPUT_OUTPUT_FILE_NAME")
 	commitMessage := os.Getenv("INPUT_COMMIT_MESSAGE")
@@ -53,7 +53,7 @@ func commitSVGChanges(file *os.File) {
 		Branch:  github.String(branch),
 		// Leave Author/Committer nil to get a bot-verified signature
 	}
-	_, _, err = gh.Repositories.CreateFile(ctx, owner, repo, path, opts) // or UpdateFile if you set SHA
+	_, _, err = gh.Repositories.CreateFile(ctx, owner, repo, path, opts)
 	if err != nil {
 		zap.L().Fatal("Failed to upload SVG file", zap.Error(err))
 	}


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds support for specifying the output branch when committing changes, making the workflow more flexible and configurable. The main changes are the addition of a new input parameter for the branch and updating the commit logic to use this parameter.

**Workflow configuration improvements:**

* Added a new `output_branch` input to `action.yml` to allow users to specify which branch to commit changes to, with a default value of `"main"`.

**Commit logic updates:**

* Updated `src/commit.go` to read the branch name from the `INPUT_OUTPUT_BRANCH` environment variable instead of hardcoding `"main"`.
* Ensured the branch specified by the user is used when creating the file in the repository during the commit operation.