### PR TITLE
build: Replace default avatar with GitHub avatar

### DIFF
--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -38,13 +38,14 @@ func generateSVGContent() []svg.Element {
 
 func generateProfileSection(userInfo *GitHubUserInfo) svg.Element {
 	return svg.G().AppendChildren(
-		// Profile avatar (image) - smaller and positioned like target
+		// Profile avatar (image) - smaller and positioned like target, with rounded corners
 		svg.Image().
 			Href(svg.String(userInfo.AvatarURL)).
 			Width(svg.Px(24)).
 			Height(svg.Px(24)).
 			X(svg.Px(18)).
-			Y(svg.Px(28)),
+			Y(svg.Px(28)).
+			RX(svg.Px(6)), // Rounded corners
 
 		// Name - positioned next to avatar
 		svg.Text(svg.CharData("Jack Plowman")).XY(50, 45, svg.Px).Fill(svg.String(textPrimary)).

--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -8,7 +8,6 @@ import (
 var title = "Jack Plowman - GitHub Stats"
 var desc = "GitHub profile statistics visualization"
 
-// Colour palette - light theme to match target
 var (
 	textPrimary   = "#24292f" // Dark text for light mode
 	textSecondary = "#656d76" // Secondary gray text
@@ -19,15 +18,16 @@ var (
 )
 
 func generateSVGContent() []svg.Element {
+	userInfo, _ := getGitHubUserInfo()
 	elements := []svg.Element{
 		svg.Title(svg.CharData(title)),
 		svg.Desc(svg.CharData(desc)),
 
 		// Profile section (top left)
-		generateProfileSection(),
+		generateProfileSection(userInfo),
 
 		// Stats sections (middle row)
-		generateStatsRow(),
+		generateStatsRow(userInfo),
 
 		// Languages section (bottom)
 		generateLanguagesSection(),
@@ -36,10 +36,15 @@ func generateSVGContent() []svg.Element {
 	return elements
 }
 
-func generateProfileSection() svg.Element {
+func generateProfileSection(userInfo *GitHubUserInfo) svg.Element {
 	return svg.G().AppendChildren(
-		// Profile avatar (circle) - smaller and positioned like target
-		svg.Circle().Fill(svg.String(accentBlue)).CXCYR(30, 40, 12, svg.Px),
+		// Profile avatar (image) - smaller and positioned like target
+		svg.Image().
+			Href(svg.String(userInfo.AvatarURL)).
+			Width(svg.Px(24)).
+			Height(svg.Px(24)).
+			X(svg.Px(18)).
+			Y(svg.Px(28)),
 
 		// Name - positioned next to avatar
 		svg.Text(svg.CharData("Jack Plowman")).XY(50, 45, svg.Px).Fill(svg.String(textPrimary)).
@@ -55,7 +60,7 @@ func generateProfileSection() svg.Element {
 	)
 }
 
-func generateStatsRow() svg.Element {
+func generateStatsRow(userInfo *GitHubUserInfo) svg.Element {
 	activityStatsX := 20.0
 	communityStatsX := 250.0
 	repositoriesStatsX := 480.0

--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -38,26 +38,23 @@ func generateSVGContent() []svg.Element {
 
 func generateProfileSection(userInfo *GitHubUserInfo) svg.Element {
 	return svg.G().AppendChildren(
-		// Profile avatar (image) - smaller and positioned like target, with rounded corners
-		svg.Image().
-			Href(svg.String(userInfo.AvatarURL)).
-			Width(svg.Px(24)).
-			Height(svg.Px(24)).
-			X(svg.Px(18)).
-			Y(svg.Px(28)).
-			RX(svg.Px(6)), // Rounded corners
+	// Use <foreignObject> for rounded avatar if <image> can't have rounded corners
+	svg.Image().
+		Href(svg.String(userInfo.AvatarURL)).
+		Width(svg.Px(24)).Height(svg.Px(24)).
+		X(svg.Px(18)).Y(svg.Px(28)).
 
-		// Name - positioned next to avatar
-		svg.Text(svg.CharData("Jack Plowman")).XY(50, 45, svg.Px).Fill(svg.String(textPrimary)).
-			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 18px; font-weight: 600;")),
+	// Name - positioned next to avatar
+	svg.Text(svg.CharData("Jack Plowman")).XY(50, 45, svg.Px).Fill(svg.String(textPrimary)).
+		Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 18px; font-weight: 600;")),
 
-		// Joined info
-		svg.Text(svg.CharData("⏰ Joined GitHub 5 years ago")).XY(20, 70, svg.Px).Fill(svg.String(textSecondary)).
-			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")),
+	// Joined info
+	svg.Text(svg.CharData("⏰ Joined GitHub 5 years ago")).XY(20, 70, svg.Px).Fill(svg.String(textSecondary)).
+		Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")),
 
-		// Followed by
-		svg.Text(svg.CharData("👥 Followed by 6 users")).XY(20, 88, svg.Px).Fill(svg.String(textSecondary)).
-			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")),
+	// Followed by
+	svg.Text(svg.CharData("👥 Followed by 6 users")).XY(20, 88, svg.Px).Fill(svg.String(textSecondary)).
+		Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")),
 	)
 }
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors the SVG generation logic to dynamically incorporate GitHub user data, specifically by passing `userInfo` throughout the SVG creation functions. This enables the profile section and stats row to use real user data, such as the avatar URL, rather than hardcoded or static values.

**Dynamic user data integration:**

* Updated `generateSVGContent` to retrieve `userInfo` from GitHub and pass it to `generateProfileSection` and `generateStatsRow`, allowing these sections to display actual user data.
* Refactored `generateProfileSection` and `generateStatsRow` to accept a `userInfo` parameter, enabling dynamic rendering of the profile avatar and statistics. [[1]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L39-R45) [[2]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L58-R61)

**Profile avatar rendering:**

* Changed the avatar rendering in `generateProfileSection` from a static circle to an `<image>` element that uses the user's real avatar URL, improving the accuracy of the profile visualization.

**Minor cleanup:**

* Removed an outdated comment regarding the color palette to streamline the code.