### PR TITLE
build: Use dynamic variables for profile section

### DIFF
--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -18,6 +18,7 @@ var (
 	greenDark     = "#216e39" // Dark green
 )
 
+// Generate the main SVG content
 func generateSVGContent() []svg.Element {
 	userInfo, _ := getGitHubUserInfo()
 	elements := []svg.Element{
@@ -37,6 +38,7 @@ func generateSVGContent() []svg.Element {
 	return elements
 }
 
+// Generate profile section of svg
 func generateProfileSection(userInfo *GitHubUserInfo) svg.Element {
 	yearsAgo := time.Since(userInfo.JoinedGitHub).Hours() / 24 / 365
 	return svg.G().AppendChildren(

--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"github.com/twpayne/go-svg"
 	"time"
-	"fmt"
 )
 
 var title = "Jack Plowman - GitHub Stats"

--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/twpayne/go-svg"
 	"time"
+	"fmt"
 )
 
 var title = "Jack Plowman - GitHub Stats"
@@ -37,27 +38,29 @@ func generateSVGContent() []svg.Element {
 }
 
 func generateProfileSection(userInfo *GitHubUserInfo) svg.Element {
+	yearsAgo := time.Since(userInfo.JoinedGitHub).Hours() / 24 / 365
 	return svg.G().AppendChildren(
-	// Use <foreignObject> for rounded avatar if <image> can't have rounded corners
-	svg.Image().
-		Href(svg.String(userInfo.AvatarURL)).
-		Width(svg.Px(24)).Height(svg.Px(24)).
-		X(svg.Px(18)).Y(svg.Px(28)).
+		// Use <foreignObject> for rounded avatar if <image> can't have rounded corners
+		svg.Image().
+			Href(svg.String(userInfo.AvatarURL)).
+			Width(svg.Px(24)).Height(svg.Px(24)).
+			X(svg.Px(18)).Y(svg.Px(28)),
 
-	// Name - positioned next to avatar
-	svg.Text(svg.CharData("Jack Plowman")).XY(50, 45, svg.Px).Fill(svg.String(textPrimary)).
-		Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 18px; font-weight: 600;")),
+		// Name - positioned next to avatar
+		svg.Text(svg.CharData(userInfo.Name)).XY(50, 45, svg.Px).Fill(svg.String(textPrimary)).
+			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 18px; font-weight: 600;")),
 
-	// Joined info
-	svg.Text(svg.CharData("⏰ Joined GitHub 5 years ago")).XY(20, 70, svg.Px).Fill(svg.String(textSecondary)).
-		Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")),
+		// Joined info
+		svg.Text(svg.CharData(fmt.Sprintf("⏰ Joined GitHub %.0f years ago", yearsAgo))).XY(20, 70, svg.Px).Fill(svg.String(textSecondary)).
+			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")),
 
-	// Followed by
-	svg.Text(svg.CharData("👥 Followed by 6 users")).XY(20, 88, svg.Px).Fill(svg.String(textSecondary)).
-		Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")),
+		// Followed by
+		svg.Text(svg.CharData(fmt.Sprintf("👥 Followed by %d users", userInfo.Followers))).XY(20, 88, svg.Px).Fill(svg.String(textSecondary)).
+			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")),
 	)
 }
 
+// Generate stats row of svg
 func generateStatsRow(userInfo *GitHubUserInfo) svg.Element {
 	activityStatsX := 20.0
 	communityStatsX := 250.0


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `generateProfileSection` function in `src/svg_content.go` to dynamically display user-specific information in the SVG profile section. The changes improve the accuracy and personalization of the SVG output by using data from the `GitHubUserInfo` struct instead of hardcoded values.

**Profile section improvements:**

* The user's name is now displayed dynamically using `userInfo.Name` instead of the hardcoded "Jack Plowman".
* The "Joined GitHub" text now calculates the number of years since the user joined GitHub using `userInfo.JoinedGitHub` and displays it with an updated format.
* The "Followed by" text now shows the actual number of followers from `userInfo.Followers` instead of a fixed value.

**Code maintenance:**

* Added the `fmt` package import to support string formatting in the profile section.

Fixes #83
Fixes #84
