### PR TITLE
ci: Add unified go linting and checking

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -50,14 +50,14 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Setup Go environment
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
-      - name: Check Go Code Format
-        run: just lint
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          version: v2.4.0
 
   run-go-dependency-vulnerability-checks:
     name: Run Go Dependency Vulnerability Checks

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Setup Go environment
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -39,23 +39,23 @@ jobs:
     with:
       language: ${{ matrix.language }}
 
-  run-go-format-checks:
-    name: Run Go Format Checks
+  run-go-format-and-lint-checks:
+    name: Run Go Format and Lint Checks
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Setup Go environment
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
       - name: Check Go Code Format
-        run: just fmt-check
+        run: just lint
 
   run-go-dependency-vulnerability-checks:
     name: Run Go Dependency Vulnerability Checks

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+# $schema: https://golangci-lint.run/jsonschema/golangci.jsonschema.json
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gosec
+
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+    - golines
+  settings:
+    gofumpt:
+      extra-rules: true

--- a/Justfile
+++ b/Justfile
@@ -8,19 +8,15 @@ export SRC_RECURSIVE := "./src/..."
 run:
     go run ${SRC_DIR}
 
-fmt:
-    go fmt ${SRC_DIR}
 
-fmt-check:
-    @if [ -z "$(gofmt -l .)" ]; \
-        then echo "OK: all Go files are go formatted."; \
-    else \
-        echo "Not go formatted:"; \
-        gofmt -l .; \
-        echo "Diff:"; \
-        gofmt -d .; \
-        exit 1; \
-    fi
+alias fmt := lint-fix
+alias fmt-check := lint
+
+lint:
+    golangci-lint run ${SRC_RECURSIVE}
+
+lint-fix:
+    golangci-lint run --fix ${SRC_RECURSIVE}
 
 vulncheck:
     govulncheck ${SRC_RECURSIVE}

--- a/Justfile
+++ b/Justfile
@@ -8,7 +8,6 @@ export SRC_RECURSIVE := "./src/..."
 run:
     go run ${SRC_DIR}
 
-
 alias fmt := lint-fix
 alias fmt-check := lint
 

--- a/src/commit.go
+++ b/src/commit.go
@@ -35,7 +35,13 @@ func commitSVGChanges(file *os.File) {
 	gh := github.NewClient(tc)
 
 	// Get current file SHA (omit if creating a new file)
-	fileContent, _, _, _ := gh.Repositories.GetContents(ctx, owner, repo, path, &github.RepositoryContentGetOptions{Ref: branch})
+	fileContent, _, _, _ := gh.Repositories.GetContents(
+		ctx,
+		owner,
+		repo,
+		path,
+		&github.RepositoryContentGetOptions{Ref: branch},
+	)
 	var sha *string
 	if fileContent != nil {
 		sha = fileContent.SHA

--- a/src/github_graphql.go
+++ b/src/github_graphql.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 const (
@@ -82,9 +84,13 @@ func (c *GitHubGraphQLClient) Query(
 
 	resp, err := c.Client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to execute request: %w", err)
+		zap.L().Fatal("Failed to query GitHub GraphQL API", zap.Error(err))
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			zap.L().Fatal("Failed to close response body", zap.Error(cerr))
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/src/github_graphql.go
+++ b/src/github_graphql.go
@@ -56,7 +56,11 @@ func NewGitHubGraphQLClient(token string) *GitHubGraphQLClient {
 }
 
 // Query executes a GraphQL query against the GitHub API
-func (c *GitHubGraphQLClient) Query(query string, variables map[string]interface{}, result interface{}) error {
+func (c *GitHubGraphQLClient) Query(
+	query string,
+	variables map[string]interface{},
+	result interface{},
+) error {
 	requestBody := GitHubGraphQLRequest{
 		Query:     query,
 		Variables: variables,
@@ -84,7 +88,11 @@ func (c *GitHubGraphQLClient) Query(query string, variables map[string]interface
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("GitHub API returned non-200 status code %d: %s", resp.StatusCode, string(body))
+		return fmt.Errorf(
+			"GitHub API returned non-200 status code %d: %s",
+			resp.StatusCode,
+			string(body),
+		)
 	}
 
 	var graphqlResp GitHubGraphQLResponse

--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -28,7 +28,10 @@ func getPullRequestTotal(username string) (int, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("GitHub API returned status %d for pull request total", resp.StatusCode)
+		return 0, fmt.Errorf(
+			"GitHub API returned status %d for pull request total",
+			resp.StatusCode,
+		)
 	}
 
 	var result struct {

--- a/src/main.go
+++ b/src/main.go
@@ -25,7 +25,6 @@ func initLogger() (*zap.Logger, error) {
 
 // main is the entry point for the application.
 func main() {
-
 	svgElements := []svg.Element{}
 	svgElements = append(svgElements, generateSVGContent()...)
 	svg := createSVG(svgElements)

--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/twpayne/go-svg"
 	"time"
+
+	"github.com/twpayne/go-svg"
 )
 
-var title = "Jack Plowman - GitHub Stats"
-var desc = "GitHub profile statistics visualization"
+var (
+	title = "Jack Plowman - GitHub Stats"
+	desc  = "GitHub profile statistics visualization"
+)
 
 var (
 	textPrimary   = "#24292f" // Dark text for light mode
@@ -53,11 +56,15 @@ func generateProfileSection(userInfo *GitHubUserInfo) svg.Element {
 			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 18px; font-weight: 600;")),
 
 		// Joined info
-		svg.Text(svg.CharData(fmt.Sprintf("⏰ Joined GitHub %.0f years ago", yearsAgo))).XY(20, 70, svg.Px).Fill(svg.String(textSecondary)).
+		svg.Text(svg.CharData(fmt.Sprintf("⏰ Joined GitHub %.0f years ago", yearsAgo))).
+			XY(20, 70, svg.Px).
+			Fill(svg.String(textSecondary)).
 			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")),
 
 		// Followed by
-		svg.Text(svg.CharData(fmt.Sprintf("👥 Followed by %d users", userInfo.Followers))).XY(20, 88, svg.Px).Fill(svg.String(textSecondary)).
+		svg.Text(svg.CharData(fmt.Sprintf("👥 Followed by %d users", userInfo.Followers))).
+			XY(20, 88, svg.Px).
+			Fill(svg.String(textSecondary)).
 			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")),
 	)
 }
@@ -73,50 +80,88 @@ func generateStatsRow(userInfo *GitHubUserInfo) svg.Element {
 	row3Y := row2Y + 16.0
 	row4Y := row3Y + 16.0
 	row5Y := row4Y + 16.0
-	headerStyle := svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 15px; font-weight: 600;")
-	textStyle := svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")
+	headerStyle := svg.String(
+		"font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 15px; font-weight: 600;",
+	)
+	textStyle := svg.String(
+		"font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;",
+	)
 	return svg.G().AppendChildren(
 		// Activity stats section
-		svg.Text(svg.CharData("📈 Activity")).XY(activityStatsX, headersRowY, svg.Px).Fill(svg.String(accentBlue)).
+		svg.Text(svg.CharData("📈 Activity")).
+			XY(activityStatsX, headersRowY, svg.Px).
+			Fill(svg.String(accentBlue)).
 			Style(headerStyle),
 
-		svg.Text(svg.CharData("○ 5560 Commits")).XY(activityStatsX, row1Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("○ 5560 Commits")).
+			XY(activityStatsX, row1Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("📋 122 Pull requests reviewed")).XY(activityStatsX, row2Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("📋 122 Pull requests reviewed")).
+			XY(activityStatsX, row2Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("🔀 4892 Pull requests opened")).XY(activityStatsX, row3Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("🔀 4892 Pull requests opened")).
+			XY(activityStatsX, row3Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("⭕ 1420 Issues opened")).XY(activityStatsX, row4Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("⭕ 1420 Issues opened")).
+			XY(activityStatsX, row4Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("💬 1872 Issue comments")).XY(activityStatsX, row5Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("💬 1872 Issue comments")).
+			XY(activityStatsX, row5Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
 
 		// Community stats section
-		svg.Text(svg.CharData("🐙 Community stats")).XY(communityStatsX, headersRowY, svg.Px).Fill(svg.String(accentBlue)).
+		svg.Text(svg.CharData("🐙 Community stats")).
+			XY(communityStatsX, headersRowY, svg.Px).
+			Fill(svg.String(accentBlue)).
 			Style(headerStyle),
 
-		svg.Text(svg.CharData("📊 Member of 0 organizations")).XY(communityStatsX, row1Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("📊 Member of 0 organizations")).
+			XY(communityStatsX, row1Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("👤 Following 13 users")).XY(communityStatsX, row2Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("👤 Following 13 users")).
+			XY(communityStatsX, row2Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("💝 Sponsoring 0 repositories")).XY(communityStatsX, row3Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("💝 Sponsoring 0 repositories")).
+			XY(communityStatsX, row3Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("⭐ Starred 136 repositories")).XY(communityStatsX, row4Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("⭐ Starred 136 repositories")).
+			XY(communityStatsX, row4Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("👀 Watching 42 repositories")).XY(communityStatsX, row5Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("👀 Watching 42 repositories")).
+			XY(communityStatsX, row5Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
 
 		// Repository stats
-		svg.Text(svg.CharData("📚 56 Repositories")).XY(repositoriesStatsX, headersRowY, svg.Px).Fill(svg.String(accentBlue)).
+		svg.Text(svg.CharData("📚 56 Repositories")).
+			XY(repositoriesStatsX, headersRowY, svg.Px).
+			Fill(svg.String(accentBlue)).
 			Style(headerStyle),
 
-		svg.Text(svg.CharData("💖 0 Sponsors")).XY(repositoriesStatsX, row1Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("💖 0 Sponsors")).
+			XY(repositoriesStatsX, row1Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("⭐ 9 Stargazers")).XY(repositoriesStatsX, row2Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("⭐ 9 Stargazers")).
+			XY(repositoriesStatsX, row2Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("🍴 9 Forkers")).XY(repositoriesStatsX, row3Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("🍴 9 Forkers")).
+			XY(repositoriesStatsX, row3Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("👁️ 38 Watchers")).XY(repositoriesStatsX, row4Y, svg.Px).Fill(svg.String(textPrimary)).
+		svg.Text(svg.CharData("👁️ 38 Watchers")).
+			XY(repositoriesStatsX, row4Y, svg.Px).
+			Fill(svg.String(textPrimary)).
 			Style(textStyle),
 
 		// Contribution graph
@@ -124,7 +169,7 @@ func generateStatsRow(userInfo *GitHubUserInfo) svg.Element {
 	)
 }
 
-func generateContributionGraph(headerStyle svg.String, textStyle svg.String) svg.Element {
+func generateContributionGraph(headerStyle, textStyle svg.String) svg.Element {
 	// Create a simple contribution graph with green squares like in the target
 	squares := []svg.Element{}
 
@@ -189,7 +234,9 @@ func generateContributionGraph(headerStyle svg.String, textStyle svg.String) svg
 	headerElements := []svg.Element{
 		svg.Text(svg.CharData("📚 Contributions")).XY(630, 115, svg.Px).Fill(svg.String(accentBlue)).
 			Style(headerStyle),
-		svg.Text(svg.CharData("Contributed to 52 repositories")).XY(630, 210, svg.Px).Fill(svg.String(textSecondary)).
+		svg.Text(svg.CharData("Contributed to 52 repositories")).
+			XY(630, 210, svg.Px).
+			Fill(svg.String(textSecondary)).
 			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 13px;")),
 	}
 
@@ -217,7 +264,9 @@ func generateLanguagesSection() svg.Element {
 		// Languages
 		svg.Text(svg.CharData("🗣️ 21 Languages")).XY(20, 220, svg.Px).Fill(svg.String(accentBlue)).
 			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 15px; font-weight: 600;")),
-		svg.Text(svg.CharData("Most used languages")).XY(400, 240, svg.Px).Fill(svg.String(accentBlue)).
+		svg.Text(svg.CharData("Most used languages")).
+			XY(400, 240, svg.Px).
+			Fill(svg.String(accentBlue)).
 			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 12px; font-weight: 600;")),
 	}
 
@@ -247,7 +296,8 @@ func generateLanguagesSection() svg.Element {
 		elements = append(elements, svg.Text(svg.CharData(lang.name)).
 			XY(float64(currentX+16), 289, svg.Px).
 			Fill(svg.String(textPrimary)).
-			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 12px;")))
+			Style(svg.String("font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 12px;")),
+		)
 
 		currentX += lang.width + 20
 	}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a major overhaul to the Go code formatting and linting workflow, transitioning from custom formatting scripts to using `golangci-lint` for both linting and auto-fixing. It also refactors SVG generation code for improved readability and maintains minor code style improvements throughout the codebase.

**CI/CD and Linting Workflow Updates:**

* The GitHub Actions workflow (`.github/workflows/code-checks.yml`) now uses `golangci-lint` for Go format and lint checks, replacing the previous custom scripts and Justfile commands. This also adds write permissions for pull requests and removes the setup for `just`.
* A new `.golangci.yml` configuration file is introduced, enabling several linters (`errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`, `gosec`) and formatters (`gofmt`, `gofumpt`, `goimports`, `golines`) with custom rules for `gofumpt`.
* The `Justfile` is updated to alias formatting commands to use `golangci-lint`, replacing the previous `go fmt` and custom format check logic. New `lint` and `lint-fix` commands are added.

**SVG Generation Code Refactoring:**

* The SVG generation functions in `src/svg_content.go` are refactored for readability: multi-line method chains are used for text elements, and some function signatures are simplified. This affects sections for profile, stats, contributions, and languages. [[1]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L56-R67) [[2]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L76-R172) [[3]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L192-R239) [[4]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L220-R269) [[5]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L250-R300)

**Minor Code Style Improvements:**

* Several functions in `src/commit.go`, `src/github_graphql.go`, and `src/github_queries.go` are updated for better readability, including multi-line function calls and error formatting. [[1]](diffhunk://#diff-d4596480fdccff713fe198cbf0bcf98788bf6179c05e3588799032ed6555921eL38-R44) [[2]](diffhunk://#diff-5c6718141c973f55227d8c1993756c5599e9848a2e888ce7694928b9be3e88c2L59-R63) [[3]](diffhunk://#diff-5c6718141c973f55227d8c1993756c5599e9848a2e888ce7694928b9be3e88c2L87-R95) [[4]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L31-R34)
* Minor cleanups such as removing unnecessary blank lines and grouping variable declarations in `src/main.go` and `src/svg_content.go`. [[1]](diffhunk://#diff-9e185f29fa355d7dd8fdd9c9ff1d0723b85206aa7d37c4eec93997005dc291ebL28) [[2]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L5-R13)

Fixes #64 
Fixes #13
