### PR TITLE
ci: Add Go Dependency Submission Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -58,6 +58,8 @@ jobs:
   go-dependency-submission:
     name: Go Dependency Submission
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -70,4 +70,4 @@ jobs:
       - name: Run snapshot action
         uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
         with:
-            go-mod-path: go.mod
+          go-mod-path: go.mod

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -54,3 +54,20 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       - name: Check Go Code Format
         run: just fmt-check
+
+  go-dependency-submission:
+    name: Go Dependency Submission
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Go environment
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+
+      - name: Run snapshot action
+        uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
+        with:
+            go-mod-path: go.mod


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new workflow job to automate Go dependency submission in the `.github/workflows/code-checks.yml` file. This enhancement helps ensure that Go dependencies are tracked and reported consistently in CI.

Continuous integration improvements:

* Added a `go-dependency-submission` job to the GitHub Actions workflow, which checks out the repository, sets up the Go environment, and runs the `actions/go-dependency-submission` action to submit Go dependencies from `go.mod`.

Fixes #19 