### PR TITLE
build: Set activity stats in SVG

### DIFF
--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -48,7 +48,8 @@ func getPullRequestTotal(username string) (int, error) {
 		zap.L().Fatal("Failed to decode pull request total response", zap.Error(err))
 	}
 
-	zap.L().Debug("Total pull requests by user", zap.String("username", username), zap.Int("total_count", result.TotalCount))
+	zap.L().
+		Debug("Total pull requests by user", zap.String("username", username), zap.Int("total_count", result.TotalCount))
 	return result.TotalCount, nil
 }
 
@@ -74,7 +75,8 @@ func getIssuesTotal(username string) (int, error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		zap.L().Fatal("GitHub API returned non-200 status for issues total", zap.Int("status", resp.StatusCode))
+		zap.L().
+			Fatal("GitHub API returned non-200 status for issues total", zap.Int("status", resp.StatusCode))
 	}
 
 	var result struct {
@@ -85,7 +87,8 @@ func getIssuesTotal(username string) (int, error) {
 		zap.L().Fatal("Failed to decode issues total response", zap.Error(err))
 	}
 
-	zap.L().Debug("Total issues by user", zap.String("username", username), zap.Int("total_count", result.TotalCount))
+	zap.L().
+		Debug("Total issues by user", zap.String("username", username), zap.Int("total_count", result.TotalCount))
 	return result.TotalCount, nil
 }
 

--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -235,3 +235,32 @@ func getCommitsTotal(username string) (int, error) {
 	fmt.Printf("Total commits by %s: %d\n", username, totalCommits)
 	return totalCommits, nil
 }
+
+type ActivityStats struct {
+	TotalCommits      int
+	TotalIssues       int
+	TotalPullRequests int
+}
+
+func getActivityStats(username string) (*ActivityStats, error) {
+	totalCommits, err := getCommitsTotal(username)
+	if err != nil {
+		zap.L().Fatal("Failed to get total commits", zap.Error(err))
+	}
+
+	totalIssues, err := getIssuesTotal(username)
+	if err != nil {
+		zap.L().Fatal("Failed to get total issues", zap.Error(err))
+	}
+
+	totalPullRequests, err := getPullRequestTotal(username)
+	if err != nil {
+		zap.L().Fatal("Failed to get total PRs", zap.Error(err))
+	}
+
+	return &ActivityStats{
+		TotalCommits:      totalCommits,
+		TotalIssues:       totalIssues,
+		TotalPullRequests: totalPullRequests,
+	}, nil
+}

--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -24,6 +24,7 @@ var (
 // Generate the main SVG content
 func generateSVGContent() []svg.Element {
 	userInfo, _ := getGitHubUserInfo()
+	activityStats, _ := getActivityStats(userInfo.Login)
 	elements := []svg.Element{
 		svg.Title(svg.CharData(title)),
 		svg.Desc(svg.CharData(desc)),
@@ -32,7 +33,7 @@ func generateSVGContent() []svg.Element {
 		generateProfileSection(userInfo),
 
 		// Stats sections (middle row)
-		generateStatsRow(userInfo),
+		generateStatsRow(userInfo, activityStats),
 
 		// Languages section (bottom)
 		generateLanguagesSection(),
@@ -70,7 +71,7 @@ func generateProfileSection(userInfo *GitHubUserInfo) svg.Element {
 }
 
 // Generate stats row of svg
-func generateStatsRow(userInfo *GitHubUserInfo) svg.Element {
+func generateStatsRow(userInfo *GitHubUserInfo, activityStats *ActivityStats) svg.Element {
 	activityStatsX := 20.0
 	communityStatsX := 250.0
 	repositoriesStatsX := 480.0
@@ -93,7 +94,7 @@ func generateStatsRow(userInfo *GitHubUserInfo) svg.Element {
 			Fill(svg.String(accentBlue)).
 			Style(headerStyle),
 
-		svg.Text(svg.CharData("○ 5560 Commits")).
+		svg.Text(svg.CharData(fmt.Sprintf("○ %d Commits", activityStats.TotalCommits))).
 			XY(activityStatsX, row1Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
@@ -101,11 +102,11 @@ func generateStatsRow(userInfo *GitHubUserInfo) svg.Element {
 			XY(activityStatsX, row2Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("🔀 4892 Pull requests opened")).
+		svg.Text(svg.CharData(fmt.Sprintf("🔀 %d Pull requests opened", activityStats.TotalPullRequests))).
 			XY(activityStatsX, row3Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("⭕ 1420 Issues opened")).
+		svg.Text(svg.CharData(fmt.Sprintf("⭕ %d Issues opened", activityStats.TotalIssues))).
 			XY(activityStatsX, row4Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors error handling in GitHub API queries to use structured logging with `zap` and introduces a new `ActivityStats` struct to centralize user activity statistics. The SVG generation logic is updated to dynamically display these statistics instead of hardcoded values.

**Logging and Error Handling Improvements:**

* Replaced all error returns and print statements in `src/github_queries.go` with structured logging using `zap.L().Fatal` and `zap.L().Debug`, ensuring consistent error reporting and improved debuggability. [[1]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L21-R28) [[2]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L48-R51) [[3]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L61-R68) [[4]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L78-R88) [[5]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L115-R114) [[6]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L124-R129) [[7]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L156-R155)

**Centralized Activity Statistics:**

* Added the `ActivityStats` struct and the `getActivityStats` function to aggregate commit, issue, and pull request totals for a user.

**SVG Generation Updates:**

* Updated `generateSVGContent` and `generateStatsRow` in `src/svg_content.go` to use `ActivityStats` for displaying dynamic user statistics, replacing previously hardcoded values. [[1]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084R27) [[2]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L35-R36) [[3]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L73-R74) [[4]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L96-R109)
