### PR TITLE
build: Remove User Id GraphQL Search

### DIFF
--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -96,7 +96,7 @@ func getIssuesTotal(username string) (int, error) {
 type GitHubUserInfo struct {
 	AvatarURL    string    `json:"avatar_url"`
 	Followers    int       `json:"followers"`
-	Id           int    `json:"id"`
+	Id           int       `json:"id"`
 	JoinedGitHub time.Time `json:"created_at"`
 	Login        string    `json:"login"`
 	Name         string    `json:"name"`

--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -96,6 +96,7 @@ func getIssuesTotal(username string) (int, error) {
 type GitHubUserInfo struct {
 	AvatarURL    string    `json:"avatar_url"`
 	Followers    int       `json:"followers"`
+	Id           int    `json:"id"`
 	JoinedGitHub time.Time `json:"created_at"`
 	Login        string    `json:"login"`
 	Name         string    `json:"name"`
@@ -135,31 +136,7 @@ func getGitHubUserInfo() (*GitHubUserInfo, error) {
 }
 
 // getCommitsTotal fetches the total number of commits made by a user to default branches across all repositories
-func getCommitsTotal(username string) (int, error) {
-	// First, get the user's ID
-	userQuery := `
-	query($login: String!) {
-		user(login: $login) {
-			id
-		}
-	}`
-
-	var userResult struct {
-		User struct {
-			ID string `json:"id"`
-		} `json:"user"`
-	}
-
-	userVariables := map[string]interface{}{
-		"login": username,
-	}
-
-	if err := QueryGitHubQLAPI(userQuery, userVariables, &userResult); err != nil {
-		zap.L().Fatal("Failed to query user ID", zap.Error(err))
-	}
-
-	userID := userResult.User.ID
-
+func getCommitsTotal(userName string, userId int) (int, error) {
 	// Now query repositories and commits using the user ID
 	query := `
 	query($login: String!, $userId: ID!, $after: String) {
@@ -186,8 +163,8 @@ func getCommitsTotal(username string) (int, error) {
 	}`
 
 	variables := map[string]interface{}{
-		"login":  username,
-		"userId": userID,
+		"login":  userName,
+		"userId": userId,
 	}
 
 	totalCommits := 0
@@ -234,7 +211,7 @@ func getCommitsTotal(username string) (int, error) {
 		cursor = result.User.Repositories.PageInfo.EndCursor
 	}
 
-	fmt.Printf("Total commits by %s: %d\n", username, totalCommits)
+	fmt.Printf("Total commits by %s: %d\n", userName, totalCommits)
 	return totalCommits, nil
 }
 
@@ -244,10 +221,10 @@ type ActivityStats struct {
 	TotalPullRequests int
 }
 
-func getActivityStats(username string) (*ActivityStats, error) {
-	totalCommits, _ := getCommitsTotal(username)
-	totalIssues, _ := getIssuesTotal(username)
-	totalPullRequests, _ := getPullRequestTotal(username)
+func getActivityStats(userName string, userId int) (*ActivityStats, error) {
+	totalCommits, _ := getCommitsTotal(userName, userId)
+	totalIssues, _ := getIssuesTotal(userName)
+	totalPullRequests, _ := getPullRequestTotal(userName)
 
 	return &ActivityStats{
 		TotalCommits:      totalCommits,

--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -24,7 +24,7 @@ var (
 // Generate the main SVG content
 func generateSVGContent() []svg.Element {
 	userInfo, _ := getGitHubUserInfo()
-	activityStats, _ := getActivityStats(userInfo.Login)
+	activityStats, _ := getActivityStats(userInfo.Login, userInfo.Id)
 	elements := []svg.Element{
 		svg.Title(svg.CharData(title)),
 		svg.Desc(svg.CharData(desc)),


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors how user information is passed between functions in `src/github_queries.go` to improve efficiency and consistency. The main change is switching from passing the username alone to passing both the username and user ID, which eliminates redundant API calls and streamlines the retrieval of user activity statistics. Additionally, the `GitHubUserInfo` struct is updated to include the user ID.

**Refactoring function signatures and data flow:**

* Updated the `GitHubUserInfo` struct to include an `Id` field, allowing user ID to be accessed directly after fetching user info.
* Refactored the `getCommitsTotal` function to accept both `userName` and `userId` as arguments, removing the need for an extra API call to fetch the user ID internally. [[1]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L138-R139) [[2]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L189-R167) [[3]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L237-R214)
* Modified the `getActivityStats` function to accept both `userName` and `userId`, and updated its internal calls to pass these arguments accordingly.

**Integration changes:**

* Updated the call to `getActivityStats` in `generateSVGContent` to provide both `userInfo.Login` and `userInfo.Id`, ensuring compatibility with the new function signature.