### PR TITLE
ci: Add common set up go dependencies action

### DIFF
--- a/.github/actions/setup-go-dependencies/action.yml
+++ b/.github/actions/setup-go-dependencies/action.yml
@@ -1,0 +1,12 @@
+name: "Setup Go Dependencies"
+description: "Sets up Go dependencies for the project"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Go environment
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      with:
+        go-version-file: go.mod
+    - name: Set up Just
+      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,6 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "super-linter/super-linter"
           - "JackPlowman/reusable-workflows"
         update-types:
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
   - package-ecosystem: "github-actions"
     commit-message:
       prefix: "deps(github-actions)"
-    directory: "/"
+    directories:
+      - "/"
+      - ".github/actions/setup-go-dependencies"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"

--- a/.github/tool-configurations/labeller.yml
+++ b/.github/tool-configurations/labeller.yml
@@ -12,11 +12,7 @@ dependencies:
 configurations:
   - any:
       - changed-files:
-          - any-glob-to-any-file:
-              [
-                ".github/other-configurations/*",
-                ".github/super-linter-configurations/*",
-              ]
+          - any-glob-to-any-file: [".github/tool-configurations/*"]
 # Language
 markdown:
   - any:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -50,10 +50,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Go environment
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: go.mod
+      - name: Set up Go dependencies
+        uses: ./.github/actions/setup-go-dependencies
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
@@ -68,12 +66,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
-      - name: Setup Go environment
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: go.mod
+      - name: Set up Go dependencies
+        uses: ./.github/actions/setup-go-dependencies
       - name: Install Go Vulnerability Checker
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run Go Vulnerability Checker
@@ -88,12 +82,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Go environment
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: go.mod
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
+      - name: Set up Go dependencies
+        uses: ./.github/actions/setup-go-dependencies
       - name: Build
         run: just build
 
@@ -108,10 +98,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Go environment
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: go.mod
+      - name: Set up Go dependencies
+        uses: ./.github/actions/setup-go-dependencies
       - name: Run snapshot action
         uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
         with:


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors how Go dependencies are set up in CI workflows by introducing a reusable composite GitHub Action and updating workflow and configuration files to use it. Additionally, it improves Dependabot and labeller configuration coverage.

**Workflow and Action Refactoring**

* Added a new composite action `.github/actions/setup-go-dependencies/action.yml` to set up both the Go environment and Just tool, consolidating their setup into a single reusable step.
* Updated `.github/workflows/code-checks.yml` to use the new composite action for Go and Just setup across all relevant jobs, replacing repeated inline steps with a single action invocation. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L53-R54) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L71-R70) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L91-R86) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L111-R102)

**Configuration Improvements**

* Modified `.github/dependabot.yml` to instruct Dependabot to monitor the new action directory for GitHub Actions updates, ensuring dependencies in custom actions are kept up-to-date.
* Updated `.github/tool-configurations/labeller.yml` to simplify and broaden the file matching pattern for tool configuration changes, making labelling more reliable.

**Minor Dependabot Exclusion Update**

* Removed an unnecessary exclusion pattern for `super-linter/super-linter` in `.github/dependabot.yml`, streamlining patch update rules.

Fixes #99
