### PR TITLE
build: Get Pull Request Review Total

### DIFF
--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -164,9 +164,10 @@ func getCommitsTotal(userName, userId string) int {
 }
 
 type GitHubTotals struct {
-	TotalPullRequests  int
-	TotalIssues        int
-	TotalIssueComments int
+	TotalPullRequests         int
+	TotalIssues               int
+	TotalIssueComments        int
+	TotalPullRequestReviews   int
 }
 
 func getGitHubTotals(userName, userId string) *GitHubTotals {
@@ -183,6 +184,11 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 			}
 			issueComments {
 				totalCount
+			}
+			contributionsCollection {
+				pullRequestReviewContributions {
+					totalCount
+				}
 			}
 		}
 	}`
@@ -202,6 +208,11 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 			IssueComments struct {
 				TotalCount int `json:"totalCount"`
 			} `json:"issueComments"`
+			ContributionsCollection struct {
+				PullRequestReviewContributions struct {
+					TotalCount int `json:"totalCount"`
+				} `json:"pullRequestReviewContributions"`
+			} `json:"contributionsCollection"`
 		} `json:"user"`
 	}
 
@@ -210,20 +221,21 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 	}
 
 	response := &GitHubTotals{
-		TotalPullRequests:  result.User.PullRequests.TotalCount,
-		TotalIssues:        result.User.Issues.TotalCount,
-		TotalIssueComments: result.User.IssueComments.TotalCount,
+		TotalPullRequests:       result.User.PullRequests.TotalCount,
+		TotalIssues:             result.User.Issues.TotalCount,
+		TotalPullRequestReviews: result.User.ContributionsCollection.PullRequestReviewContributions.TotalCount,
 	}
 	zap.L().
-		Debug("GitHub totals fetched", zap.Int("total_pull_requests", response.TotalPullRequests), zap.Int("total_issues", response.TotalIssues), zap.Int("total_issue_comments", response.TotalIssueComments))
+		Debug("GitHub totals fetched", zap.Int("total_pull_requests", response.TotalPullRequests), zap.Int("total_issues", response.TotalIssues), zap.Int("total_pr_reviews", response.TotalPullRequestReviews))
 	return response
 }
 
 type ActivityStats struct {
-	TotalCommits       int
-	TotalIssues        int
-	TotalPullRequests  int
-	TotalIssueComments int
+	TotalCommits             int
+	TotalIssues              int
+	TotalPullRequests        int
+	TotalIssueComments       int
+	TotalPullRequestReviews  int
 }
 
 func getActivityStats(userName, userId string) *ActivityStats {
@@ -231,9 +243,9 @@ func getActivityStats(userName, userId string) *ActivityStats {
 	totalCommits := getCommitsTotal(userName, userId)
 
 	return &ActivityStats{
-		TotalCommits:       totalCommits,
-		TotalPullRequests:  totals.TotalPullRequests,
-		TotalIssues:        totals.TotalIssues,
-		TotalIssueComments: totals.TotalIssueComments,
+		TotalCommits:            totalCommits,
+		TotalPullRequests:       totals.TotalPullRequests,
+		TotalIssues:             totals.TotalIssues,
+		TotalPullRequestReviews: totals.TotalPullRequestReviews,
 	}
 }

--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -164,10 +164,10 @@ func getCommitsTotal(userName, userId string) int {
 }
 
 type GitHubTotals struct {
-	TotalPullRequests         int
-	TotalIssues               int
-	TotalIssueComments        int
-	TotalPullRequestReviews   int
+	TotalPullRequests       int
+	TotalIssues             int
+	TotalIssueComments      int
+	TotalPullRequestReviews int
 }
 
 func getGitHubTotals(userName, userId string) *GitHubTotals {
@@ -231,11 +231,11 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 }
 
 type ActivityStats struct {
-	TotalCommits             int
-	TotalIssues              int
-	TotalPullRequests        int
-	TotalIssueComments       int
-	TotalPullRequestReviews  int
+	TotalCommits            int
+	TotalIssues             int
+	TotalPullRequests       int
+	TotalIssueComments      int
+	TotalPullRequestReviews int
 }
 
 func getActivityStats(userName, userId string) *ActivityStats {

--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -81,7 +81,6 @@ func generateStatsRow(userInfo *GitHubUserInfo, activityStats *ActivityStats) sv
 	row2Y := row1Y + 16.0
 	row3Y := row2Y + 16.0
 	row4Y := row3Y + 16.0
-	row5Y := row4Y + 16.0
 	headerStyle := svg.String(
 		"font-family: -apple-system, BlinkMacSystemFont, Segoe UI; font-size: 15px; font-weight: 600;",
 	)
@@ -99,7 +98,7 @@ func generateStatsRow(userInfo *GitHubUserInfo, activityStats *ActivityStats) sv
 			XY(activityStatsX, row1Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("📋 1111 Pull requests reviewed")).
+		svg.Text(svg.CharData(fmt.Sprintf("📋 %d Pull requests reviewed", activityStats.TotalPullRequestReviews))).
 			XY(activityStatsX, row2Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
@@ -109,10 +108,6 @@ func generateStatsRow(userInfo *GitHubUserInfo, activityStats *ActivityStats) sv
 			Style(textStyle),
 		svg.Text(svg.CharData(fmt.Sprintf("⭕ %d Issues opened", activityStats.TotalIssues))).
 			XY(activityStatsX, row4Y, svg.Px).
-			Fill(svg.String(textPrimary)).
-			Style(textStyle),
-		svg.Text(svg.CharData("💬 1111 Issue comments")).
-			XY(activityStatsX, row5Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
 
@@ -130,16 +125,12 @@ func generateStatsRow(userInfo *GitHubUserInfo, activityStats *ActivityStats) sv
 			XY(communityStatsX, row2Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("💝 Sponsoring 0 repositories")).
+		svg.Text(svg.CharData("⭐ Starred 136 repositories")).
 			XY(communityStatsX, row3Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("⭐ Starred 136 repositories")).
-			XY(communityStatsX, row4Y, svg.Px).
-			Fill(svg.String(textPrimary)).
-			Style(textStyle),
 		svg.Text(svg.CharData("👀 Watching 42 repositories")).
-			XY(communityStatsX, row5Y, svg.Px).
+			XY(communityStatsX, row4Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub statistics functionality to include the total number of pull request reviews for a user and removes the issue comments stat from the SVG output. The changes ensure that pull request review counts are fetched from the GitHub API, stored, and displayed in the stats row, while also simplifying the SVG layout by removing less relevant stats.

**GitHub statistics enhancements:**

* Added `TotalPullRequestReviews` to the `GitHubTotals` and `ActivityStats` structs to track the number of pull request reviews a user has performed. [[1]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72R170) [[2]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72R238)
* Updated the GitHub API query and response parsing in `getGitHubTotals` to fetch and store pull request review contributions. [[1]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72R188-R192) [[2]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72R211-R215)
* Modified `getActivityStats` to include `TotalPullRequestReviews` in its output.

**SVG stats row updates:**

* Changed the stats row to display the actual number of pull request reviews using the new `TotalPullRequestReviews` field, replacing the previous hardcoded value.
* Removed the issue comments stat from the SVG output, simplifying the visual representation.

**SVG layout simplification:**

* Adjusted row calculations and removed the sponsoring stat, updating the positioning of starred and watching repository stats for a cleaner layout. [[1]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L84) [[2]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L133-R133)
