### PR TITLE
build: Get Watching, Organisations and Sponsors

### DIFF
--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -165,11 +165,13 @@ func getCommitsTotal(userName, userId string) int {
 }
 
 type GitHubTotals struct {
-	TotalPullRequests       int
-	TotalIssues             int
-	TotalPullRequestReviews int
-	TotalStarredRepos       int
-	TotalSponsors           int
+	TotalPullRequests          int
+	TotalIssues                int
+	TotalPullRequestReviews    int
+	TotalStarredRepos          int
+	TotalSponsors              int
+	TotalMemberOfOrganizations int
+	TotalWatchers              int
 }
 
 func getGitHubTotals(userName, userId string) *GitHubTotals {
@@ -192,7 +194,13 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 			starredRepositories {
 				totalCount
 			}
-			sponsorshipsAsSponsor {
+			sponsorshipsAsMaintainer {
+				totalCount
+			}
+			organizations {
+				totalCount
+			}
+			watching {
 				totalCount
 			}
 		}
@@ -210,9 +218,6 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 			PullRequests struct {
 				TotalCount int `json:"totalCount"`
 			} `json:"pullRequests"`
-			IssueComments struct {
-				TotalCount int `json:"totalCount"`
-			} `json:"issueComments"`
 			ContributionsCollection struct {
 				PullRequestReviewContributions struct {
 					TotalCount int `json:"totalCount"`
@@ -221,9 +226,15 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 			StarredRepositories struct {
 				TotalCount int `json:"totalCount"`
 			} `json:"starredRepositories"`
-			SponsorshipsAsSponsor struct {
+			SponsorshipsAsMaintainer struct {
 				TotalCount int `json:"totalCount"`
-			} `json:"sponsorshipsAsSponsor"`
+			} `json:"sponsorshipsAsMaintainer"`
+			Organizations struct {
+				TotalCount int `json:"totalCount"`
+			} `json:"organizations"`
+			Watching struct {
+				TotalCount int `json:"totalCount"`
+			} `json:"watching"`
 		} `json:"user"`
 	}
 
@@ -232,11 +243,13 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 	}
 
 	response := &GitHubTotals{
-		TotalPullRequests:       result.User.PullRequests.TotalCount,
-		TotalIssues:             result.User.Issues.TotalCount,
-		TotalPullRequestReviews: result.User.ContributionsCollection.PullRequestReviewContributions.TotalCount,
-		TotalStarredRepos:       result.User.StarredRepositories.TotalCount,
-		TotalSponsors:           result.User.SponsorshipsAsSponsor.TotalCount,
+		TotalPullRequests:          result.User.PullRequests.TotalCount,
+		TotalIssues:                result.User.Issues.TotalCount,
+		TotalPullRequestReviews:    result.User.ContributionsCollection.PullRequestReviewContributions.TotalCount,
+		TotalStarredRepos:          result.User.StarredRepositories.TotalCount,
+		TotalSponsors:              result.User.SponsorshipsAsMaintainer.TotalCount,
+		TotalMemberOfOrganizations: result.User.Organizations.TotalCount,
+		TotalWatchers:              result.User.Watching.TotalCount,
 	}
 	zap.L().
 		Debug("GitHub totals fetched",
@@ -244,17 +257,22 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 			zap.Int("total_issues", response.TotalIssues),
 			zap.Int("total_pr_reviews", response.TotalPullRequestReviews),
 			zap.Int("total_starred_repos", response.TotalStarredRepos),
-			zap.Int("total_sponsors", response.TotalSponsors))
+			zap.Int("total_sponsors", response.TotalSponsors),
+			zap.Int("total_member_of_organizations", response.TotalMemberOfOrganizations),
+			zap.Int("total_watchers", response.TotalWatchers),
+		)
 	return response
 }
 
 type GitHubTotalsStats struct {
-	TotalCommits            int
-	TotalIssues             int
-	TotalPullRequests       int
-	TotalPullRequestReviews int
-	TotalStarredRepos       int
-	TotalSponsors           int
+	TotalCommits               int
+	TotalIssues                int
+	TotalPullRequests          int
+	TotalPullRequestReviews    int
+	TotalStarredRepos          int
+	TotalSponsors              int
+	TotalMemberOfOrganizations int
+	TotalWatchers              int
 }
 
 func getGitHubTotalsStats(userName, userId string) *GitHubTotalsStats {
@@ -262,11 +280,13 @@ func getGitHubTotalsStats(userName, userId string) *GitHubTotalsStats {
 	totalCommits := getCommitsTotal(userName, userId)
 
 	return &GitHubTotalsStats{
-		TotalCommits:            totalCommits,
-		TotalPullRequests:       totals.TotalPullRequests,
-		TotalIssues:             totals.TotalIssues,
-		TotalPullRequestReviews: totals.TotalPullRequestReviews,
-		TotalStarredRepos:       totals.TotalStarredRepos,
-		TotalSponsors:           totals.TotalSponsors,
+		TotalCommits:               totalCommits,
+		TotalPullRequests:          totals.TotalPullRequests,
+		TotalIssues:                totals.TotalIssues,
+		TotalPullRequestReviews:    totals.TotalPullRequestReviews,
+		TotalStarredRepos:          totals.TotalStarredRepos,
+		TotalSponsors:              totals.TotalSponsors,
+		TotalMemberOfOrganizations: totals.TotalMemberOfOrganizations,
+		TotalWatchers:              totals.TotalWatchers,
 	}
 }

--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -117,7 +117,7 @@ func generateStatsRow(userInfo *GitHubUserInfo, githubTotalsStats *GitHubTotalsS
 			Fill(svg.String(accentBlue)).
 			Style(headerStyle),
 
-		svg.Text(svg.CharData("📊 Member of 0 organizations")).
+		svg.Text(svg.CharData(fmt.Sprintf("📊 Member of %d organizations", githubTotalsStats.TotalMemberOfOrganizations))).
 			XY(communityStatsX, row1Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
@@ -140,7 +140,7 @@ func generateStatsRow(userInfo *GitHubUserInfo, githubTotalsStats *GitHubTotalsS
 			Fill(svg.String(accentBlue)).
 			Style(headerStyle),
 
-		svg.Text(svg.CharData("💖 0 Sponsors")).
+		svg.Text(svg.CharData(fmt.Sprintf("💖 %d Sponsors", githubTotalsStats.TotalSponsors))).
 			XY(repositoriesStatsX, row1Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
@@ -152,7 +152,7 @@ func generateStatsRow(userInfo *GitHubUserInfo, githubTotalsStats *GitHubTotalsS
 			XY(repositoriesStatsX, row3Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),
-		svg.Text(svg.CharData("👁️ 38 Watchers")).
+		svg.Text(svg.CharData(fmt.Sprintf("👁️ %d Watchers", githubTotalsStats.TotalWatchers))).
 			XY(repositoriesStatsX, row4Y, svg.Px).
 			Fill(svg.String(textPrimary)).
 			Style(textStyle),


### PR DESCRIPTION
# Pull Request

## Description

This pull request enhances the GitHub statistics collection and display by adding new metrics and improving the accuracy of existing ones. The main improvements include tracking the number of organizations a user belongs to and the number of watchers, as well as updating the sponsor count logic. These updates are reflected both in the data structures and the SVG output for user stats.

**GitHub statistics data model and collection:**

* Added `TotalMemberOfOrganizations` and `TotalWatchers` fields to the `GitHubTotals` and `GitHubTotalsStats` structs, and updated the data fetching logic to collect these metrics from the GitHub API. [[1]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72R173-R174) [[2]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L195-R203) [[3]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L224-R237) [[4]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L239-R263) [[5]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72R274-R275) [[6]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72R289-R290)

* Changed sponsor count logic to use `sponsorshipsAsMaintainer` instead of `sponsorshipsAsSponsor` for more accurate representation of sponsorships. [[1]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L195-R203) [[2]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L224-R237) [[3]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L239-R263)

**SVG stats row output:**

* Updated the SVG output to dynamically display the number of organizations, sponsors, and watchers using the new and updated fields, replacing the previous hardcoded values. [[1]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L120-R120) [[2]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L143-R143) [[3]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L155-R155)