### PR TITLE
chore: Add Go Lint pre-commit hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,3 +24,7 @@ pre-commit:
       run: just actionlint-check
     EditorConfig Check:
       run: just editorconfig-check
+    Go Lint Check:
+      run: just lint
+    Go Vulnerability Check:
+      run: just vulncheck


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds new automated checks the `lefthook.yml` configuration to improve code quality and security for Go projects.

New Go checks added:

* Go Lint Check: Runs `just lint` to ensure Go code adheres to linting standards.
* Go Vulnerability Check: Runs `just vulncheck` to scan for security vulnerabilities in Go dependencies.

Fixes #115 
