### PR TITLE
ci: Update Pull Request Tasks Permissions

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   check-pr-title:
     name: Check Pull Request Title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check Pull Request Title
         uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the GitHub Actions workflow configuration by relocating the `pull-requests: read` permission from the global workflow level to the specific job that requires it.

- Workflow permissions management:
  * Removed the global `pull-requests: read` permission and instead set `permissions: {}` at the workflow level in `.github/workflows/pull-request-tasks.yml`.
  * Added `pull-requests: read` permission specifically to the `check-pr-title` job, ensuring least privilege is granted only where necessary.