### PR TITLE
bug: Avatar Fix 

### DIFF
--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -1,16 +1,20 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
 )
 
 const bearerPrefix = "Bearer "
+const maxAvatarBytes = 2 * 1024 * 1024
 
 // getGitHubUserInfo fetches the user's information from GitHub REST API
 type GitHubUserInfo struct {
@@ -75,6 +79,87 @@ func normalizeAvatarURL(avatarURL string) string {
 	parsed.RawQuery = query.Encode()
 
 	return parsed.String()
+}
+
+// getAvatarHref returns a self-contained avatar data URI where possible.
+// SVGs embedded as images often cannot load external image subresources, so
+// using a data URI keeps the GitHub avatar visible in README/profile renders.
+func getAvatarHref(avatarURL string) string {
+	normalizedURL := normalizeAvatarURL(avatarURL)
+	if normalizedURL == "" {
+		return ""
+	}
+
+	dataURI := fetchAvatarDataURI(
+		&http.Client{Timeout: 15 * time.Second},
+		normalizedURL,
+	)
+	if dataURI != "" {
+		return dataURI
+	}
+
+	return normalizedURL
+}
+
+func fetchAvatarDataURI(client *http.Client, avatarURL string) string {
+	req, err := http.NewRequest("GET", avatarURL, nil)
+	if err != nil {
+		zap.L().Warn("Failed to create avatar request", zap.String("avatar_url", avatarURL), zap.Error(err))
+		return ""
+	}
+	req.Header.Set("Accept", "image/*")
+	req.Header.Set("User-Agent", "coding-metrics")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		zap.L().Warn("Failed to fetch avatar", zap.String("avatar_url", avatarURL), zap.Error(err))
+		return ""
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			zap.L().Warn("Failed to close avatar response body", zap.Error(cerr))
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		zap.L().Warn("Avatar request returned non-200 status",
+			zap.String("avatar_url", avatarURL),
+			zap.Int("status", resp.StatusCode))
+		return ""
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAvatarBytes+1))
+	if err != nil {
+		zap.L().Warn("Failed to read avatar response", zap.String("avatar_url", avatarURL), zap.Error(err))
+		return ""
+	}
+	if len(body) == 0 || len(body) > maxAvatarBytes {
+		zap.L().Warn("Avatar response was empty or too large",
+			zap.String("avatar_url", avatarURL),
+			zap.Int("bytes", len(body)))
+		return ""
+	}
+
+	contentType := cleanImageContentType(resp.Header.Get("Content-Type"), body)
+	if contentType == "" {
+		zap.L().Warn("Avatar response was not an image",
+			zap.String("avatar_url", avatarURL),
+			zap.String("content_type", resp.Header.Get("Content-Type")))
+		return ""
+	}
+
+	return "data:" + contentType + ";base64," + base64.StdEncoding.EncodeToString(body)
+}
+
+func cleanImageContentType(contentType string, body []byte) string {
+	contentType = strings.TrimSpace(strings.Split(contentType, ";")[0])
+	if contentType == "" {
+		contentType = http.DetectContentType(body)
+	}
+	if !strings.HasPrefix(contentType, "image/") {
+		return ""
+	}
+	return contentType
 }
 
 // GetUserId fetches the user ID for a given username

--- a/src/github_queries_test.go
+++ b/src/github_queries_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeAvatarURLAddsSizeParameter(t *testing.T) {
+	got := normalizeAvatarURL("https://avatars.githubusercontent.com/u/12345?v=4")
+
+	if !strings.Contains(got, "s=80") {
+		t.Fatalf("expected normalized avatar URL to include s=80, got %q", got)
+	}
+	if !strings.Contains(got, "v=4") {
+		t.Fatalf("expected normalized avatar URL to preserve existing query values, got %q", got)
+	}
+}
+
+func TestNormalizeAvatarURLKeepsExistingSize(t *testing.T) {
+	got := normalizeAvatarURL("https://avatars.githubusercontent.com/u/12345?s=40")
+
+	if strings.Contains(got, "s=80") {
+		t.Fatalf("expected normalized avatar URL to preserve explicit size, got %q", got)
+	}
+}
+
+func TestFetchAvatarDataURIEmbedsImage(t *testing.T) {
+	avatarBytes := []byte("fake-png-bytes")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Accept"); got != "image/*" {
+			t.Fatalf("expected image Accept header, got %q", got)
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(avatarBytes)
+	}))
+	t.Cleanup(server.Close)
+
+	got := fetchAvatarDataURI(server.Client(), server.URL)
+	want := "data:image/png;base64," + base64.StdEncoding.EncodeToString(avatarBytes)
+
+	if got != want {
+		t.Fatalf("expected embedded avatar data URI %q, got %q", want, got)
+	}
+}
+
+func TestFetchAvatarDataURIRejectsNonImage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":"nope"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	if got := fetchAvatarDataURI(server.Client(), server.URL); got != "" {
+		t.Fatalf("expected non-image response to be rejected, got %q", got)
+	}
+}

--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -556,8 +556,8 @@ func calculateAveragePerDay(total, days int) float64 {
 func generateProfileSection(userInfo *GitHubUserInfo) svg.Element {
 	yearsAgo := time.Since(userInfo.JoinedGitHub).Hours() / 24 / 365
 
-	// Point to hosted avatar so GitHub README sanitization keeps the image
-	avatarURL := normalizeAvatarURL(userInfo.AvatarURL)
+	// Embed the avatar so it renders when the SVG is displayed as an image.
+	avatarURL := getAvatarHref(userInfo.AvatarURL)
 	avatarImage := svg.Image().
 		Href(svg.String(avatarURL)).
 		Width(svg.Px(24)).Height(svg.Px(24)).
@@ -569,7 +569,7 @@ func generateProfileSection(userInfo *GitHubUserInfo) svg.Element {
 	avatarImage.Attrs["xlink:href"] = svg.String(avatarURL)
 
 	return svg.G().AppendChildren(
-		// Use <image> element with both href variants so sanitizers retain the avatar
+		// Use both href variants so SVG consumers with old xlink handling still work.
 		avatarImage,
 
 		// Name - positioned next to avatar


### PR DESCRIPTION
# Pull Request

## Description

This pull request improves how GitHub avatars are handled and rendered in SVGs, ensuring avatars are embedded directly as data URIs when possible. This change increases compatibility with GitHub README/profile SVG rendering, especially for SVGs that cannot load external images. The update also adds comprehensive tests for the new avatar logic.

**Avatar Embedding and Handling Improvements:**

* Introduced `getAvatarHref` and supporting functions in `github_queries.go` to fetch avatars, embed them as data URIs (base64-encoded image data), and only fall back to external URLs if embedding fails. This ensures avatars display reliably in SVGs, even when external resources are blocked.
* Updated `generateProfileSection` in `svg_content.go` to use the new embedded avatar approach, replacing direct links to hosted avatars with embedded data URIs for improved rendering in GitHub READMEs/profiles.
* Adjusted SVG `<image>` handling to ensure compatibility with both modern and older SVG consumers by setting both `href` and `xlink:href` attributes.

**Testing Enhancements:**

* Added a new test suite in `github_queries_test.go` to verify avatar URL normalization, image embedding as data URIs, and rejection of non-image responses, increasing confidence in the new logic.

**Dependency and Constant Updates:**

* Added necessary imports (`base64`, `io`, `strings`) and defined `maxAvatarBytes` to limit avatar image size.
