### PR TITLE
chore: Fix Linter/Formatter Issues

### DIFF
--- a/src/github_graphql.go
+++ b/src/github_graphql.go
@@ -41,16 +41,14 @@ type GitHubGraphQLError struct {
 
 // GitHubGraphQLClient provides a client for making GraphQL requests to GitHub
 type GitHubGraphQLClient struct {
-	Token    string
-	Endpoint string
-	Client   *http.Client
+	Token  string
+	Client *http.Client
 }
 
 // NewGitHubGraphQLClient creates a new GitHub GraphQL client
 func NewGitHubGraphQLClient(token string) *GitHubGraphQLClient {
 	return &GitHubGraphQLClient{
-		Token:    token,
-		Endpoint: DefaultGitHubGraphQLEndpoint,
+		Token: token,
 		Client: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -73,7 +71,7 @@ func (c *GitHubGraphQLClient) Query(
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", c.Endpoint, bytes.NewBuffer(reqBytes))
+	req, err := http.NewRequest("POST", DefaultGitHubGraphQLEndpoint, bytes.NewBuffer(reqBytes))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -13,8 +13,10 @@ import (
 	"go.uber.org/zap"
 )
 
-const bearerPrefix = "Bearer "
-const maxAvatarBytes = 2 * 1024 * 1024
+const (
+	bearerPrefix   = "Bearer "
+	maxAvatarBytes = 2 * 1024 * 1024
+)
 
 // getGitHubUserInfo fetches the user's information from GitHub REST API
 type GitHubUserInfo struct {
@@ -104,7 +106,11 @@ func getAvatarHref(avatarURL string) string {
 func fetchAvatarDataURI(client *http.Client, avatarURL string) string {
 	req, err := http.NewRequest("GET", avatarURL, nil)
 	if err != nil {
-		zap.L().Warn("Failed to create avatar request", zap.String("avatar_url", avatarURL), zap.Error(err))
+		zap.L().Warn(
+			"Failed to create avatar request",
+			zap.String("avatar_url", avatarURL),
+			zap.Error(err),
+		)
 		return ""
 	}
 	req.Header.Set("Accept", "image/*")
@@ -130,7 +136,11 @@ func fetchAvatarDataURI(client *http.Client, avatarURL string) string {
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAvatarBytes+1))
 	if err != nil {
-		zap.L().Warn("Failed to read avatar response", zap.String("avatar_url", avatarURL), zap.Error(err))
+		zap.L().Warn(
+			"Failed to read avatar response",
+			zap.String("avatar_url", avatarURL),
+			zap.Error(err),
+		)
 		return ""
 	}
 	if len(body) == 0 || len(body) > maxAvatarBytes {


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several small improvements to code organization and logging formatting, as well as a minor change to how the GitHub GraphQL endpoint is handled. The main updates are improved grouping of constants, more readable logging statements, and simplification of the GraphQL client.

**Code organization and readability improvements:**

* Grouped related constants (`bearerPrefix` and `maxAvatarBytes`) into a single `const` block for better organization in `src/github_queries.go`.

**Logging improvements:**

* Reformatted logging statements in `fetchAvatarDataURI` to use multi-line style for better readability and consistency. [[1]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L107-R113) [[2]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L133-R143)

**GraphQL client simplification:**

* Removed the `Endpoint` field from the `GitHubGraphQLClient` struct and now always uses `DefaultGitHubGraphQLEndpoint` directly when creating requests, simplifying the client’s configuration. [[1]](diffhunk://#diff-5c6718141c973f55227d8c1993756c5599e9848a2e888ce7694928b9be3e88c2L45-L53) [[2]](diffhunk://#diff-5c6718141c973f55227d8c1993756c5599e9848a2e888ce7694928b9be3e88c2L76-R74)