### PR TITLE
bug: Fix GitHub Limits

### DIFF
--- a/src/github_graphql.go
+++ b/src/github_graphql.go
@@ -31,6 +31,7 @@ type GitHubGraphQLResponse struct {
 
 // GitHubGraphQLError represents an error in a GraphQL response
 type GitHubGraphQLError struct {
+	Type      string `json:"type"`
 	Message   string `json:"message"`
 	Locations []struct {
 		Line   int `json:"line"`
@@ -80,10 +81,27 @@ func (c *GitHubGraphQLClient) Query(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
+	startedAt := time.Now()
 	resp, err := c.Client.Do(req)
 	if err != nil {
-		zap.L().Fatal("Failed to query GitHub GraphQL API", zap.Error(err))
+		return fmt.Errorf(
+			"failed to query GitHub GraphQL API after %s: %w",
+			time.Since(startedAt),
+			err,
+		)
 	}
+	zap.L().Debug(
+		"GitHub GraphQL response",
+		zap.Int("status", resp.StatusCode),
+		zap.Duration("duration", time.Since(startedAt)),
+		zap.String("rate_limit_limit", resp.Header.Get("X-RateLimit-Limit")),
+		zap.String("rate_limit_remaining", resp.Header.Get("X-RateLimit-Remaining")),
+		zap.String("rate_limit_used", resp.Header.Get("X-RateLimit-Used")),
+		zap.String("rate_limit_reset", resp.Header.Get("X-RateLimit-Reset")),
+		zap.String("rate_limit_resource", resp.Header.Get("X-RateLimit-Resource")),
+		zap.String("retry_after", resp.Header.Get("Retry-After")),
+		zap.String("request_id", resp.Header.Get("X-GitHub-Request-Id")),
+	)
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
 			zap.L().Fatal("Failed to close response body", zap.Error(cerr))
@@ -109,8 +127,19 @@ func (c *GitHubGraphQLClient) Query(
 
 	if len(graphqlResp.Errors) > 0 {
 		errorMessages := ""
-		for _, err := range graphqlResp.Errors {
-			errorMessages += err.Message + "; "
+		for _, graphqlErr := range graphqlResp.Errors {
+			zap.L().Warn(
+				"GitHub GraphQL error",
+				zap.String("type", graphqlErr.Type),
+				zap.Any("path", graphqlErr.Path),
+				zap.String("message", graphqlErr.Message),
+			)
+			errorMessages += fmt.Sprintf(
+				"%s at %v: %s; ",
+				graphqlErr.Type,
+				graphqlErr.Path,
+				graphqlErr.Message,
+			)
 		}
 		return fmt.Errorf("GraphQL errors: %s", errorMessages)
 	}

--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -562,14 +563,66 @@ type ContributionWeek struct {
 	ContributionDays []ContributionDay
 }
 
-// getContributionCalendar fetches the user's contribution calendar from GitHub
+// getContributionCalendar fetches the user's contribution calendar from GitHub.
+// Use bounded ranges from the outset: a full-year calendar can exceed GitHub's
+// per-query compute limit and failed parent queries can quickly trigger the
+// secondary rate limit before an adaptive split reaches a safe range.
 func getContributionCalendar(userName string) *ContributionCalendar {
-	zap.L().Debug("Fetching contribution calendar")
+	const (
+		calendarChunkDays  = 28
+		calendarChunkPause = 200 * time.Millisecond
+	)
 
+	today := startOfUTCDay(time.Now())
+	start := today.AddDate(-1, 0, 0)
+	start = start.AddDate(0, 0, -int(start.Weekday()))
+	zap.L().Debug(
+		"Fetching contribution calendar in bounded ranges",
+		zap.String("from", start.Format("2006-01-02")),
+		zap.String("to", today.Format("2006-01-02")),
+		zap.Int("chunk_days", calendarChunkDays),
+	)
+
+	calendars := make([]*ContributionCalendar, 0, 14)
+	chunkStart := start
+	chunkIndex := 0
+	for !chunkStart.After(today) {
+		chunkEnd := chunkStart.AddDate(0, 0, calendarChunkDays-1)
+		if chunkEnd.After(today) {
+			chunkEnd = today
+		}
+		chunkIndex++
+		zap.L().Debug(
+			"Fetching contribution calendar chunk",
+			zap.Int("chunk", chunkIndex),
+			zap.String("from", chunkStart.Format("2006-01-02")),
+			zap.String("to", chunkEnd.Format("2006-01-02")),
+		)
+
+		calendar, err := getContributionCalendarRange(userName, chunkStart, chunkEnd)
+		if err != nil {
+			zap.L().Fatal("Failed to get contribution calendar chunk", zap.Error(err))
+		}
+		calendars = append(calendars, calendar)
+		chunkStart = chunkEnd.AddDate(0, 0, 1)
+		if !chunkStart.After(today) {
+			time.Sleep(calendarChunkPause)
+		}
+	}
+
+	calendar := mergeContributionCalendars(start, today, calendars...)
+	logContributionCalendarFetched(calendar, true)
+	return calendar
+}
+
+func queryContributionCalendar(
+	userName string,
+	from, to *time.Time,
+) (*ContributionCalendar, error) {
 	query := `
-	query($login: String!) {
+	query($login: String!, $from: DateTime, $to: DateTime) {
 		user(login: $login) {
-			contributionsCollection {
+			contributionsCollection(from: $from, to: $to) {
 				contributionCalendar {
 					totalContributions
 					weeks {
@@ -584,8 +637,11 @@ func getContributionCalendar(userName string) *ContributionCalendar {
 		}
 	}`
 
-	variables := map[string]interface{}{
-		"login": userName,
+	variables := map[string]interface{}{"login": userName}
+	if from != nil && to != nil {
+		variables["from"] = from.Format(time.RFC3339)
+		endOfDay := to.Add(24*time.Hour - time.Second)
+		variables["to"] = endOfDay.Format(time.RFC3339)
 	}
 
 	var result struct {
@@ -594,11 +650,7 @@ func getContributionCalendar(userName string) *ContributionCalendar {
 				ContributionCalendar struct {
 					TotalContributions int `json:"totalContributions"`
 					Weeks              []struct {
-						ContributionDays []struct {
-							Date              string `json:"date"`
-							ContributionCount int    `json:"contributionCount"`
-							Color             string `json:"color"`
-						} `json:"contributionDays"`
+						ContributionDays []ContributionDay `json:"contributionDays"`
 					} `json:"weeks"`
 				} `json:"contributionCalendar"`
 			} `json:"contributionsCollection"`
@@ -606,35 +658,117 @@ func getContributionCalendar(userName string) *ContributionCalendar {
 	}
 
 	if err := QueryGitHubQLAPI(query, variables, &result); err != nil {
-		zap.L().Fatal("Failed to get contribution calendar", zap.Error(err))
+		return nil, err
 	}
 
-	// Convert the result to our data structure
+	queryCalendar := result.User.ContributionsCollection.ContributionCalendar
 	calendar := &ContributionCalendar{
-		TotalContributions: result.User.ContributionsCollection.ContributionCalendar.TotalContributions,
-		Weeks:              make([]ContributionWeek, 0),
+		TotalContributions: queryCalendar.TotalContributions,
+		Weeks:              make([]ContributionWeek, 0, len(queryCalendar.Weeks)),
+	}
+	for _, week := range queryCalendar.Weeks {
+		calendar.Weeks = append(
+			calendar.Weeks,
+			ContributionWeek{ContributionDays: week.ContributionDays},
+		)
+	}
+	return calendar, nil
+}
+
+func getContributionCalendarRange(
+	userName string,
+	from, to time.Time,
+) (*ContributionCalendar, error) {
+	zap.L().Debug(
+		"Fetching contribution calendar range",
+		zap.String("from", from.Format("2006-01-02")),
+		zap.String("to", to.Format("2006-01-02")),
+	)
+	calendar, err := queryContributionCalendar(userName, &from, &to)
+	if err == nil {
+		return calendar, nil
 	}
 
-	for _, week := range result.User.ContributionsCollection.ContributionCalendar.Weeks {
-		contributionWeek := ContributionWeek{
-			ContributionDays: make([]ContributionDay, 0),
-		}
-		for _, day := range week.ContributionDays {
-			contributionWeek.ContributionDays = append(
-				contributionWeek.ContributionDays,
-				ContributionDay{
-					Date:              day.Date,
-					ContributionCount: day.ContributionCount,
-					Color:             day.Color,
-				},
-			)
-		}
-		calendar.Weeks = append(calendar.Weeks, contributionWeek)
+	days := int(to.Sub(from).Hours()/24) + 1
+	if !isGraphQLResourceLimitError(err) || days <= 7 {
+		return nil, fmt.Errorf(
+			"contribution calendar range %s to %s: %w",
+			from.Format("2006-01-02"),
+			to.Format("2006-01-02"),
+			err,
+		)
 	}
 
-	zap.L().Debug("Contribution calendar fetched",
+	midpoint := from.AddDate(0, 0, (days/2)-1)
+	rightStart := midpoint.AddDate(0, 0, 1)
+	zap.L().Warn(
+		"Contribution calendar range exceeded GitHub resources; splitting range",
+		zap.String("from", from.Format("2006-01-02")),
+		zap.String("to", to.Format("2006-01-02")),
+		zap.Int("days", days),
+		zap.String("left_to", midpoint.Format("2006-01-02")),
+		zap.String("right_from", rightStart.Format("2006-01-02")),
+	)
+
+	left, err := getContributionCalendarRange(userName, from, midpoint)
+	if err != nil {
+		return nil, err
+	}
+	right, err := getContributionCalendarRange(userName, rightStart, to)
+	if err != nil {
+		return nil, err
+	}
+	return mergeContributionCalendars(from, to, left, right), nil
+}
+
+func mergeContributionCalendars(
+	from, to time.Time,
+	calendars ...*ContributionCalendar,
+) *ContributionCalendar {
+	byDate := make(map[string]ContributionDay)
+	for _, calendar := range calendars {
+		for _, week := range calendar.Weeks {
+			for _, day := range week.ContributionDays {
+				byDate[day.Date] = day
+			}
+		}
+	}
+
+	merged := &ContributionCalendar{Weeks: make([]ContributionWeek, 0)}
+	week := ContributionWeek{ContributionDays: make([]ContributionDay, 0, 7)}
+	for date := from; !date.After(to); date = date.AddDate(0, 0, 1) {
+		dateString := date.Format("2006-01-02")
+		day, ok := byDate[dateString]
+		if !ok {
+			day = ContributionDay{Date: dateString, Color: githubContribNone}
+		}
+		merged.TotalContributions += day.ContributionCount
+		week.ContributionDays = append(week.ContributionDays, day)
+		if len(week.ContributionDays) == 7 {
+			merged.Weeks = append(merged.Weeks, week)
+			week = ContributionWeek{ContributionDays: make([]ContributionDay, 0, 7)}
+		}
+	}
+	if len(week.ContributionDays) > 0 {
+		merged.Weeks = append(merged.Weeks, week)
+	}
+	return merged
+}
+
+func isGraphQLResourceLimitError(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "resource limit")
+}
+
+func startOfUTCDay(value time.Time) time.Time {
+	utc := value.UTC()
+	return time.Date(utc.Year(), utc.Month(), utc.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func logContributionCalendarFetched(calendar *ContributionCalendar, usedBoundedRanges bool) {
+	zap.L().Debug(
+		"Contribution calendar fetched",
 		zap.Int("total_contributions", calendar.TotalContributions),
-		zap.Int("total_weeks", len(calendar.Weeks)))
-
-	return calendar
+		zap.Int("total_weeks", len(calendar.Weeks)),
+		zap.Bool("used_bounded_ranges", usedBoundedRanges),
+	)
 }

--- a/src/github_queries.go
+++ b/src/github_queries.go
@@ -26,6 +26,7 @@ type GitHubUserInfo struct {
 	JoinedGitHub time.Time `json:"created_at"`
 	Login        string    `json:"login"`
 	Name         string    `json:"name"`
+	NodeID       string    `json:"node_id"`
 	PublicGists  int       `json:"public_gists"`
 	PublicRepos  int       `json:"public_repos"`
 	Type         string    `json:"type"`
@@ -172,33 +173,6 @@ func cleanImageContentType(contentType string, body []byte) string {
 	return contentType
 }
 
-// GetUserId fetches the user ID for a given username
-func getUserId(userName string) string {
-	zap.L().Debug("Fetching user ID", zap.String("username", userName))
-	userQuery := `
-	query($login: String!) {
-		user(login: $login) {
-			id
-		}
-	}`
-
-	var userResult struct {
-		User struct {
-			ID string `json:"id"`
-		} `json:"user"`
-	}
-
-	userVariables := map[string]interface{}{
-		"login": userName,
-	}
-
-	if err := QueryGitHubQLAPI(userQuery, userVariables, &userResult); err != nil {
-		zap.L().Fatal("Failed to query user ID", zap.Error(err))
-	}
-
-	return userResult.User.ID
-}
-
 // getCommitsTotal fetches the total number of commits made by a user to default branches across all repositories
 func getCommitsTotal(userName, userId string) int {
 	zap.L().
@@ -292,7 +266,7 @@ type GitHubTotals struct {
 	TotalWatchers              int
 }
 
-func getGitHubTotals(userName, userId string) *GitHubTotals {
+func getGitHubTotals(userName string) *GitHubTotals {
 	zap.L().
 		Debug("Fetching GitHub totals")
 	query := `
@@ -303,11 +277,6 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 			}
 			pullRequests {
 				totalCount
-			}
-			contributionsCollection {
-				pullRequestReviewContributions {
-					totalCount
-				}
 			}
 			starredRepositories {
 				totalCount
@@ -336,11 +305,6 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 			PullRequests struct {
 				TotalCount int `json:"totalCount"`
 			} `json:"pullRequests"`
-			ContributionsCollection struct {
-				PullRequestReviewContributions struct {
-					TotalCount int `json:"totalCount"`
-				} `json:"pullRequestReviewContributions"`
-			} `json:"contributionsCollection"`
 			StarredRepositories struct {
 				TotalCount int `json:"totalCount"`
 			} `json:"starredRepositories"`
@@ -363,7 +327,7 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 	response := &GitHubTotals{
 		TotalPullRequests:          result.User.PullRequests.TotalCount,
 		TotalIssues:                result.User.Issues.TotalCount,
-		TotalPullRequestReviews:    result.User.ContributionsCollection.PullRequestReviewContributions.TotalCount,
+		TotalPullRequestReviews:    getPullRequestReviewTotal(userName),
 		TotalStarredRepos:          result.User.StarredRepositories.TotalCount,
 		TotalSponsors:              result.User.SponsorshipsAsMaintainer.TotalCount,
 		TotalMemberOfOrganizations: result.User.Organizations.TotalCount,
@@ -382,6 +346,33 @@ func getGitHubTotals(userName, userId string) *GitHubTotals {
 	return response
 }
 
+func getPullRequestReviewTotal(userName string) int {
+	query := `
+	query($login: String!) {
+		user(login: $login) {
+			contributionsCollection {
+				totalPullRequestReviewContributions
+			}
+		}
+	}`
+
+	var result struct {
+		User struct {
+			ContributionsCollection struct {
+				TotalPullRequestReviewContributions int `json:"totalPullRequestReviewContributions"`
+			} `json:"contributionsCollection"`
+		} `json:"user"`
+	}
+
+	variables := map[string]interface{}{"login": userName}
+	if err := QueryGitHubQLAPI(query, variables, &result); err != nil {
+		zap.L().Warn("Failed to get pull request review total", zap.Error(err))
+		return 0
+	}
+
+	return result.User.ContributionsCollection.TotalPullRequestReviewContributions
+}
+
 type GitHubTotalsStats struct {
 	TotalCommits               int
 	TotalIssues                int
@@ -394,7 +385,7 @@ type GitHubTotalsStats struct {
 }
 
 func getGitHubTotalsStats(userName, userId string) *GitHubTotalsStats {
-	totals := getGitHubTotals(userName, userId)
+	totals := getGitHubTotals(userName)
 	totalCommits := getCommitsTotal(userName, userId)
 
 	return &GitHubTotalsStats{

--- a/src/github_queries_test.go
+++ b/src/github_queries_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNormalizeAvatarURLAddsSizeParameter(t *testing.T) {
@@ -55,5 +57,47 @@ func TestFetchAvatarDataURIRejectsNonImage(t *testing.T) {
 
 	if got := fetchAvatarDataURI(server.Client(), server.URL); got != "" {
 		t.Fatalf("expected non-image response to be rejected, got %q", got)
+	}
+}
+
+func TestMergeContributionCalendarsDeduplicatesAndFillsMissingDays(t *testing.T) {
+	from := time.Date(2026, time.July, 12, 0, 0, 0, 0, time.UTC)
+	to := from.AddDate(0, 0, 7)
+	left := &ContributionCalendar{Weeks: []ContributionWeek{{ContributionDays: []ContributionDay{
+		{Date: "2026-07-12", ContributionCount: 2, Color: githubContribLow},
+		{Date: "2026-07-13", ContributionCount: 3, Color: githubContribMediumLow},
+	}}}}
+	right := &ContributionCalendar{Weeks: []ContributionWeek{{ContributionDays: []ContributionDay{
+		{Date: "2026-07-13", ContributionCount: 4, Color: githubContribMediumHigh},
+		{Date: "2026-07-19", ContributionCount: 5, Color: githubContribHigh},
+	}}}}
+
+	got := mergeContributionCalendars(from, to, left, right)
+
+	if got.TotalContributions != 11 {
+		t.Fatalf("expected deduplicated total of 11, got %d", got.TotalContributions)
+	}
+	if len(got.Weeks) != 2 ||
+		len(got.Weeks[0].ContributionDays) != 7 ||
+		len(got.Weeks[1].ContributionDays) != 1 {
+		t.Fatalf("expected one full and one partial week, got %#v", got.Weeks)
+	}
+	if got.Weeks[0].ContributionDays[1].ContributionCount != 4 {
+		t.Fatalf("expected later duplicate to win, got %#v", got.Weeks[0].ContributionDays[1])
+	}
+	if got.Weeks[0].ContributionDays[2].Color != githubContribNone {
+		t.Fatalf(
+			"expected missing day to use the no-contribution colour, got %#v",
+			got.Weeks[0].ContributionDays[2],
+		)
+	}
+}
+
+func TestIsGraphQLResourceLimitError(t *testing.T) {
+	if !isGraphQLResourceLimitError(errors.New("RESOURCE LIMITS for this query exceeded")) {
+		t.Fatal("expected resource-limit error to be recognized")
+	}
+	if isGraphQLResourceLimitError(errors.New("bad credentials")) {
+		t.Fatal("did not expect authentication error to be recognized as a resource limit")
 	}
 }

--- a/src/svg_content.go
+++ b/src/svg_content.go
@@ -42,10 +42,9 @@ var currentColourProfile ColourProfile
 // Generate the main SVG content
 func generateSVGContent() []svg.Element {
 	userInfo := getGitHubUserInfo()
-	userId := getUserId(userInfo.Login)
-	githubTotalsStats := getGitHubTotalsStats(userInfo.Login, userId)
-	languageStats := getLanguageStats(userInfo.Login)
 	contributionCalendar := getContributionCalendar(userInfo.Login)
+	githubTotalsStats := getGitHubTotalsStats(userInfo.Login, userInfo.NodeID)
+	languageStats := getLanguageStats(userInfo.Login)
 	elements := []svg.Element{
 		svg.Title(svg.CharData(title)),
 		svg.Desc(svg.CharData(desc)),


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors how user IDs are handled in GitHub statistics queries, simplifies related function signatures, and improves the retrieval of pull request review totals. The main change is to use the `NodeID` field from the `GitHubUserInfo` struct instead of fetching the user ID separately, and to move the pull request review count to a dedicated query.

**GitHub user identification and statistics:**
* Added a `NodeID` field to the `GitHubUserInfo` struct, allowing direct access to the user's node ID from the initial user info query.
* Removed the `getUserId` function and updated all usages to rely on the `NodeID` from `GitHubUserInfo`, simplifying function signatures such as `getGitHubTotals` to only require `userName`. [[1]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L175-L201) [[2]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L295-R269) [[3]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L397-R388) [[4]](diffhunk://#diff-e143f9fe5e4895d2c5578d30da8411d33cefe2760b7412afb27a03730340c084L45-R47)

**Pull request review statistics:**
* Moved the pull request review total query into a new dedicated function, `getPullRequestReviewTotal`, and updated `getGitHubTotals` to use this function. This separates concerns and improves code clarity. [[1]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L307-L311) [[2]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L339-L343) [[3]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72L366-R330) [[4]](diffhunk://#diff-3484c064e28785bb18a3283c10677b69f66d514631e0422d7d336ab28fea9e72R349-R375)

**Other updates:**
* Updated the SVG generation logic to use the new approach for fetching user IDs and statistics, ensuring consistency across the codebase.